### PR TITLE
Add initial ./src file structure

### DIFF
--- a/src/action/manager.c
+++ b/src/action/manager.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/action/manager.c
+++ b/src/action/manager.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "action/manager.h"
+

--- a/src/action/manager.h
+++ b/src/action/manager.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_ACTION_MANAGER_H__
+#define __WS_ACTION_MANAGER_H__
+
+
+
+#endif // __WS_ACTION_MANAGER_H__

--- a/src/action/manager.h
+++ b/src/action/manager.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/command/processor.c
+++ b/src/command/processor.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/command/processor.c
+++ b/src/command/processor.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "command/processor.h"
+

--- a/src/command/processor.h
+++ b/src/command/processor.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_COMMAND_PROCESSOR_H__
+#define __WS_COMMAND_PROCESSOR_H__
+
+
+
+#endif // __WS_COMMAND_PROCESSOR_H__

--- a/src/command/processor.h
+++ b/src/command/processor.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/compositor/module.c
+++ b/src/compositor/module.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/compositor/module.c
+++ b/src/compositor/module.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "compositor/module.h"
+

--- a/src/compositor/module.h
+++ b/src/compositor/module.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_COMPOSITOR_MODULE_H__
+#define __WS_COMPOSITOR_MODULE_H__
+
+
+
+#endif // __WS_COMPOSITOR_MODULE_H__

--- a/src/compositor/module.h
+++ b/src/compositor/module.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/connection/manager.c
+++ b/src/connection/manager.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "connection/manager.h"
+

--- a/src/connection/manager.c
+++ b/src/connection/manager.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/connection/manager.h
+++ b/src/connection/manager.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/connection/manager.h
+++ b/src/connection/manager.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_CONNECTION_MANAGER_H__
+#define __WS_CONNECTION_MANAGER_H__
+
+
+
+#endif // __WS_CONNECTION_MANAGER_H__

--- a/src/logger/module.c
+++ b/src/logger/module.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/logger/module.c
+++ b/src/logger/module.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "logger/module.h"
+

--- a/src/logger/module.h
+++ b/src/logger/module.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_LOGGER_MODULE_H__
+#define __WS_LOGGER_MODULE_H__
+
+
+
+#endif // __WS_LOGGER_MODULE_H__

--- a/src/logger/module.h
+++ b/src/logger/module.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "objects/array.h"
+

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/array.h
+++ b/src/objects/array.h
@@ -25,3 +25,10 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_OBJECTS_ARRAY_H__
+#define __WS_OBJECTS_ARRAY_H__
+
+
+
+#endif // __WS_OBJECTS_ARRAY_H__
+

--- a/src/objects/array.h
+++ b/src/objects/array.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "objects/object.h"
+

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_OBJECTS_OBJECT_H__
+#define __WS_OBJECTS_OBJECT_H__
+
+
+
+#endif // __WS_OBJECTS_OBJECT_H__

--- a/src/objects/queue.c
+++ b/src/objects/queue.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "objects/queue.h"
+

--- a/src/objects/queue.c
+++ b/src/objects/queue.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/queue.h
+++ b/src/objects/queue.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_OBJECTS_QUEUE_H__
+#define __WS_OBJECTS_QUEUE_H__
+
+
+
+#endif // __WS_OBJECTS_QUEUE_H__

--- a/src/objects/queue.h
+++ b/src/objects/queue.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/stack.c
+++ b/src/objects/stack.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "objects/stack.h"
+

--- a/src/objects/stack.c
+++ b/src/objects/stack.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/stack.h
+++ b/src/objects/stack.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_OBJECTS_STACK_H__
+#define __WS_OBJECTS_STACK_H__
+
+
+
+#endif // __WS_OBJECTS_STACK_H__

--- a/src/objects/stack.h
+++ b/src/objects/stack.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "objects/string.h"
+

--- a/src/objects/string.h
+++ b/src/objects/string.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_OBJECTS_STRING_H__
+#define __WS_OBJECTS_STRING_H__
+
+
+
+#endif // __WS_OBJECTS_STRING_H__

--- a/src/objects/string.h
+++ b/src/objects/string.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/serialize/module.c
+++ b/src/serialize/module.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "serialize/module.h"
+

--- a/src/serialize/module.c
+++ b/src/serialize/module.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/serialize/module.h
+++ b/src/serialize/module.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_SERIALIZE_MODULE_H__
+#define __WS_SERIALIZE_MODULE_H__
+
+
+
+#endif // __WS_SERIALIZE_MODULE_H__

--- a/src/serialize/module.h
+++ b/src/serialize/module.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/session/manager.c
+++ b/src/session/manager.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "session/manager.h"
+

--- a/src/session/manager.c
+++ b/src/session/manager.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/session/manager.h
+++ b/src/session/manager.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_SESSION_MANAGER_H__
+#define __WS_SESSION_MANAGER_H__
+
+
+
+#endif // __WS_SESSION_MANAGER_H__

--- a/src/session/manager.h
+++ b/src/session/manager.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/storage/module.c
+++ b/src/storage/module.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "storage/module.h"
+

--- a/src/storage/module.c
+++ b/src/storage/module.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/storage/module.h
+++ b/src/storage/module.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_STORAGE_MODULE_H__
+#define __WS_STORAGE_MODULE_H__
+
+
+
+#endif // __WS_STORAGE_MODULE_H__

--- a/src/storage/module.h
+++ b/src/storage/module.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/util/arithmetical.h
+++ b/src/util/arithmetical.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_UTIL_ARITHMETICAL_H__
+#define __WS_UTIL_ARITHMETICAL_H__
+
+
+
+#endif // __WS_UTIL_ARITHMETICAL_H__

--- a/src/util/arithmetical.h
+++ b/src/util/arithmetical.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/util/attributes.h
+++ b/src/util/attributes.h
@@ -25,8 +25,8 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __WAYSOME_ATTRIBUTES_H__
-#define __WAYSOME_ATTRIBUTES_H__
+#ifndef __WS_UTIL_ATTRIBUTES_H__
+#define __WS_UTIL_ATTRIBUTES_H__
 
 /*
  * @file attributes.h
@@ -117,4 +117,4 @@
 
 #endif // __GNUC__
 
-#endif // __WAYSOME_ATTRIBUTES_H__
+#endif // __WS_UTIL_ATTRIBUTES_H__

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_UTIL_DEBUG_H__
+#define __WS_UTIL_DEBUG_H__
+
+
+
+#endif // __WS_UTIL_DEBUG_H__

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/util/logical.h
+++ b/src/util/logical.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_UTIL_LOGICAL_H__
+#define __WS_UTIL_LOGICAL_H__
+
+
+
+#endif // __WS_UTIL_LOGICAL_H__

--- a/src/util/logical.h
+++ b/src/util/logical.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/bool.c
+++ b/src/values/bool.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/bool.h"
+

--- a/src/values/bool.c
+++ b/src/values/bool.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/bool.h
+++ b/src/values/bool.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_BOOL_H__
+#define __WS_VALUES_BOOL_H__
+
+
+
+#endif // __WS_VALUES_BOOL_H__

--- a/src/values/bool.h
+++ b/src/values/bool.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/int.c
+++ b/src/values/int.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/int.h"
+

--- a/src/values/int.c
+++ b/src/values/int.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/int.h
+++ b/src/values/int.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/int.h
+++ b/src/values/int.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_INT_H__
+#define __WS_VALUES_INT_H__
+
+
+
+#endif // __WS_VALUES_INT_H__

--- a/src/values/nil.c
+++ b/src/values/nil.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/nil.c
+++ b/src/values/nil.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/nil.h"
+

--- a/src/values/nil.h
+++ b/src/values/nil.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_NIL_H__
+#define __WS_VALUES_NIL_H__
+
+
+
+#endif // __WS_VALUES_NIL_H__

--- a/src/values/nil.h
+++ b/src/values/nil.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/object_id.c
+++ b/src/values/object_id.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/object_id.c
+++ b/src/values/object_id.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/object_id.h"
+

--- a/src/values/object_id.h
+++ b/src/values/object_id.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_OBJECT_ID_H__
+#define __WS_VALUES_OBJECT_ID_H__
+
+
+
+#endif // __WS_VALUES_OBJECT_ID_H__

--- a/src/values/object_id.h
+++ b/src/values/object_id.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/set.c
+++ b/src/values/set.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/set.c
+++ b/src/values/set.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/set.h"
+

--- a/src/values/set.h
+++ b/src/values/set.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_SET_H__
+#define __WS_VALUES_SET_H__
+
+
+
+#endif // __WS_VALUES_SET_H__

--- a/src/values/set.h
+++ b/src/values/set.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/string.c
+++ b/src/values/string.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/string.h"
+

--- a/src/values/string.c
+++ b/src/values/string.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/string.h
+++ b/src/values/string.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_STRING_H__
+#define __WS_VALUES_STRING_H__
+
+
+
+#endif // __WS_VALUES_STRING_H__

--- a/src/values/string.h
+++ b/src/values/string.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/value.c
+++ b/src/values/value.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/value.h"
+

--- a/src/values/value.c
+++ b/src/values/value.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/value.h
+++ b/src/values/value.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_VALUE_H__
+#define __WS_VALUES_VALUE_H__
+
+
+
+#endif // __WS_VALUES_VALUE_H__

--- a/src/values/value.h
+++ b/src/values/value.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/value_named.c
+++ b/src/values/value_named.c
@@ -25,3 +25,5 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "values/value_named.h"
+

--- a/src/values/value_named.c
+++ b/src/values/value_named.c
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/values/value_named.h
+++ b/src/values/value_named.h
@@ -25,3 +25,9 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __WS_VALUES_VALUE_NAMED_H__
+#define __WS_VALUES_VALUE_NAMED_H__
+
+
+
+#endif // __WS_VALUES_VALUE_NAMED_H__

--- a/src/values/value_named.h
+++ b/src/values/value_named.h
@@ -1,0 +1,27 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+


### PR DESCRIPTION
This PR adds the initial structure for `./src`, including files which only contain the license header by now.
