### PR TITLE
Add build env libdrm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(HARD_MODE "Enables extra checks for use during development" OFF)
 #
 # Dependencies
 #
+find_package(DRM REQUIRED)
 find_package(EGL REQUIRED)
 find_package(EV REQUIRED)
 find_package(IcuIO REQUIRED)

--- a/cmake/Modules/FindDRM.cmake
+++ b/cmake/Modules/FindDRM.cmake
@@ -1,0 +1,28 @@
+# - Try to find libdrm
+# Once done this will define
+#  DRM_FOUND - System has libdrm
+#  DRM_INCLUDE_DIRS - The libdrm include directories
+#  DRM_LIBRARIES - The libraries needed for libdrm
+#  DRM_DEFINITIONS - Compiler switches required for using libdrm
+
+find_package(PkgConfig)
+pkg_check_modules(PC_DRM QUIET libdrm)
+set(DRM_DEFINITIONS ${PC_DRM_CFLAGS_OTHER})
+
+find_path(DRM_INCLUDE_DIR drm.h
+    HINTS ${PC_DRM_INCLUDEDIR} ${PC_DRM_INCLUDE_DIRS})
+
+find_library(DRM_LIBRARY drm
+        HINTS ${PC_DRM_LIBDIR} ${PC_DRM_LIBRARY_DIRS})
+
+set(DRM_INCLUDE_DIRS ${DRM_INCLUDE_DIR})
+set(DRM_LIBRARIES ${DRM_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set DRM_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(DRM DEFAULT_MSG
+    DRM_INCLUDE_DIR DRM_LIBRARY)
+
+mark_as_advanced(DRM_INCLUDE_DIR DRM_LIBRARY)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@
 include_directories(
     ${PROJECT_SOURCE_DIR}/src
 
+    ${DRM_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
     ${ICU_OP_INCLUDE_DIRS}
     ${ICU_UC_INCLUDE_DIRS}
@@ -22,6 +23,7 @@ include_directories(
 # Add definitions
 #
 add_definitions(
+    ${DRM_DEFINITIONS}
     ${EGL_DEFINITIONS}
     ${ICU_OP_DEFINITIONS}
     ${ICU_UC_DEFINITIONS}
@@ -73,6 +75,7 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
 add_executable(waysome ${SOURCE_FILES})
 
 target_link_libraries(waysome
+    ${DRM_LIBRARIES}
     ${EGL_LIBRARIES}
     ${PNG_LIBRARIES}
     ${UDEV_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(
 
     ${DRM_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
+    ${EV_INCLUDE_DIRS}
     ${ICU_OP_INCLUDE_DIRS}
     ${ICU_UC_INCLUDE_DIRS}
     ${PNG_INCLUDE_DIRS}
@@ -25,6 +26,7 @@ include_directories(
 add_definitions(
     ${DRM_DEFINITIONS}
     ${EGL_DEFINITIONS}
+    ${EV_DEFINITIONS}
     ${ICU_OP_DEFINITIONS}
     ${ICU_UC_DEFINITIONS}
     ${PNG_DEFINITIONS}
@@ -77,6 +79,7 @@ add_executable(waysome ${SOURCE_FILES})
 target_link_libraries(waysome
     ${DRM_LIBRARIES}
     ${EGL_LIBRARIES}
+    ${EV_LIBRARIES}
     ${PNG_LIBRARIES}
     ${UDEV_LIBRARIES}
     ${WAYLAND_CURSOR_LIBRARIES}


### PR DESCRIPTION
Add `libdrm` to build dependencies.
Targets issue #41.
