### PR TITLE
Add object hashing callback and ws_object_hash() function

### DIFF
--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -219,6 +219,14 @@ ws_object_run(
     return false;
 }
 
+size_t
+ws_object_hash(
+    struct ws_object* self
+) {
+    /** @todo implement */
+    return 0;
+}
+
 bool
 ws_object_lock_read(
     struct ws_object* self

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -223,8 +223,17 @@ size_t
 ws_object_hash(
     struct ws_object* self
 ) {
-    /** @todo implement */
-    return 0;
+    if (!self || !self->id || !self->id->hash_callback) {
+        return 0;
+    }
+
+    size_t hash;
+
+    pthread_rwlock_rdlock(&self->rw_lock);
+    hash = self->id->hash_callback(self);
+    pthread_rwlock_unlock(&self->rw_lock);
+
+    return hash;
 }
 
 bool

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -73,6 +73,11 @@ typedef bool (*ws_object_log_callback)(struct ws_object* const, void*);
  */
 typedef bool (*ws_object_run_callback)(struct ws_object* const);
 
+/**
+ * hash callback
+ */
+typedef size_t (*ws_object_hash_callback)(struct ws_object* const);
+
 /*
  *
  * Type implementation
@@ -90,6 +95,7 @@ struct ws_object_type {
     ws_object_deinit_callback deinit_callback; //!< Free callback for the type
     ws_object_log_callback log_callback; //!< Log callback for the type
     ws_object_run_callback run_callback; //!< Run callback for the type
+    ws_object_hash_callback hash_callback; //!< Hash callback for the type
 };
 
 /**

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -268,6 +268,18 @@ ws_object_run(
 );
 
 /**
+ * Hash the object
+ *
+ * @memberof ws_object
+ *
+ * @return the object hash as a `size_t`
+ */
+size_t
+ws_object_hash(
+    struct ws_object* self //!< The object
+);
+
+/**
  * Read-lock the object
  *
  * @memberof ws_object


### PR DESCRIPTION
This PR adds the possibility to hash an object.

It also provides a _very_ basic "hashing" function for the object type itself.
