### PR TITLE
Move: ws_array_init() to init callback

### DIFF
--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -41,6 +41,16 @@
  */
 
 /**
+ * Init callback for array type
+ *
+ * @return true if initialisation worked, else false
+ */
+static bool
+init_callback(
+    struct ws_object* self //!< Array object
+);
+
+/**
  * Deinit callback for array type
  */
 static bool
@@ -60,6 +70,7 @@ ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY = {
     .supertype  = &WS_OBJECT_TYPE_ID_OBJECT,
     .typestr    = "ws_array",
 
+    .init_callback = init_callback,
     .deinit_callback = deinit_callback,
 };
 
@@ -71,37 +82,13 @@ ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY = {
  *
  */
 
-bool
-ws_array_init(
-    struct ws_array* self
-) {
-    if (self) {
-        self->len = 2; // initialize with two elements
-        self->ary = calloc(self->len, sizeof(*self->ary));
-
-        if (!self->ary) {
-            return false;
-        }
-
-        ws_object_init(&self->obj);
-        self->obj.id = &WS_OBJECT_TYPE_ID_ARRAY;
-
-        self->nused = 0;
-        self->sorted = false;
-
-        return true;
-    }
-
-    return false;
-}
-
 struct ws_array*
 ws_array_new(void)
 {
     struct ws_array* a = calloc(1, sizeof(*a));
 
     if (a) {
-        ws_array_init(a);
+        ws_object_init(&a->obj);
     }
 
     return a;
@@ -281,6 +268,35 @@ ws_array_append(
  *
  *
  */
+
+static bool
+init_callback(
+    struct ws_object* obj
+) {
+    if (obj->id != &WS_OBJECT_TYPE_ID_ARRAY) {
+        return false;
+    }
+
+    struct ws_array* self = (struct ws_array*) obj;
+    if (self) {
+        self->len = 2; // initialize with two elements
+        self->ary = calloc(self->len, sizeof(*self->ary));
+
+        if (!self->ary) {
+            return false;
+        }
+
+        ws_object_init(&self->obj);
+        self->obj.id = &WS_OBJECT_TYPE_ID_ARRAY;
+
+        self->nused = 0;
+        self->sorted = false;
+
+        return true;
+    }
+
+    return false;
+}
 
 static bool
 deinit_callback(

--- a/src/objects/array.h
+++ b/src/objects/array.h
@@ -66,19 +66,11 @@ struct ws_array {
 extern ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY;
 
 /**
- * Initialize an array object
- *
- * @return true if initialisation worked, else false
- */
-bool
-ws_array_init(
-    struct ws_array* self //!< Array object
-);
-
-/**
  * Allocate a new, initialized array object
  *
  * @memberof ws_array
+ *
+ * @note One ref is already taken
  *
  * @return New array object, initialized. NULL on failure
  */


### PR DESCRIPTION
The ws_object type allows init callbacks, so the init function for the
object type should be used here.

One addition is added as well: The init callback does a type check
internally and returns false if the type is not an array.
