### PR TITLE
Fix: Potential endless recursion bug

### DIFF
--- a/src/values/value.c
+++ b/src/values/value.c
@@ -28,6 +28,8 @@
 #include "values/value.h"
 #include "values/value_type.h"
 
+#include "util/condition.h"
+
 void
 ws_value_init(
     struct ws_value* self
@@ -43,7 +45,8 @@ ws_value_deinit(
     struct ws_value* self
 ) {
     if (self) {
-        if (self->deinit_callback && self->deinit_callback != ws_value_deinit) {
+        if (self->deinit_callback &&
+                likely(self->deinit_callback != ws_value_deinit)) {
             self->deinit_callback(self);
         }
     }

--- a/src/values/value.c
+++ b/src/values/value.c
@@ -43,7 +43,7 @@ ws_value_deinit(
     struct ws_value* self
 ) {
     if (self) {
-        if (self->deinit_callback) {
+        if (self->deinit_callback && self->deinit_callback != ws_value_deinit) {
             self->deinit_callback(self);
         }
     }


### PR DESCRIPTION
Fix: Potential endless recursion bug if `deinit_callback` member
is set to `ws_value_deinit`.
