### PR TITLE
Remove ws_object-internal oneline-helpers

### DIFF
--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -53,14 +53,6 @@ wrlock(
     struct ws_object* const obj //!< The object to write-lock
 );
 
-/**
- * Alias: `pthread_rwlock_unlock(&obj->rw_lock);
- */
-static inline void
-unlock(
-    struct ws_object* const obj //!< The object to unlock
-);
-
 
 /*
  * Type information
@@ -103,7 +95,7 @@ ws_object_get_type_id(
         ws_object_type_id* id;
         rdlock(self);
         id = self->id;
-        unlock(self);
+        ws_object_unlock(self);
         return id;
     }
     return NULL;
@@ -117,7 +109,7 @@ ws_object_get_settings(
         enum ws_object_settings s;
         rdlock(self);
         s = self->settings;
-        unlock(self);
+        ws_object_unlock(self);
         return s;
     }
 
@@ -132,7 +124,7 @@ ws_object_set_settings(
     if (self) {
         wrlock(self);
         self->settings = settings;
-        unlock(self);
+        ws_object_unlock(self);
     }
 }
 
@@ -166,7 +158,7 @@ ws_object_getref(
     if (self) {
         wrlock(self);
         self->ref_counting.refcnt++;
-        unlock(self);
+        ws_object_unlock(self);
         return self;
     }
 
@@ -186,7 +178,7 @@ ws_object_unref(
             pthread_rwlock_destroy(&self->ref_counting.rwl);
             free(self);
         } else {
-            unlock(self);
+            ws_object_unlock(self);
         }
     }
 }
@@ -211,7 +203,7 @@ ws_object_run(
         if (self->id && self->id->run_callback) {
             b = self->id->run_callback(self);
         }
-        unlock(self);
+        ws_object_unlock(self);
 
         return b;
     }
@@ -310,11 +302,4 @@ wrlock(
     struct ws_object* const obj //!< The object to write-lock
 ) {
     pthread_rwlock_wrlock(&obj->rw_lock);
-}
-
-static inline void
-unlock(
-    struct ws_object* const obj
-) {
-    pthread_rwlock_unlock(&obj->rw_lock);
 }

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -45,14 +45,6 @@ rdlock(
     struct ws_object* const obj //!< The object to read-lock
 );
 
-/**
- * Alias: `pthread_rwlock_wrlock(&obj->rw_lock);
- */
-static inline void
-wrlock(
-    struct ws_object* const obj //!< The object to write-lock
-);
-
 
 /*
  * Type information
@@ -122,7 +114,7 @@ ws_object_set_settings(
     enum ws_object_settings settings
 ) {
     if (self) {
-        wrlock(self);
+        ws_object_lock_write(self);
         self->settings = settings;
         ws_object_unlock(self);
     }
@@ -156,7 +148,7 @@ ws_object_getref(
     struct ws_object* self
 ) {
     if (self) {
-        wrlock(self);
+        ws_object_lock_write(self);
         self->ref_counting.refcnt++;
         ws_object_unlock(self);
         return self;
@@ -170,7 +162,7 @@ ws_object_unref(
     struct ws_object* self
 ) {
     if (self) {
-        wrlock(self);
+        ws_object_lock_write(self);
         self->ref_counting.refcnt--;
 
         if (self->ref_counting.refcnt == 0) {
@@ -268,7 +260,7 @@ ws_object_deinit(
     struct ws_object* self
 ) {
     if (self) {
-        wrlock(self);
+        ws_object_lock_write(self);
         if (self->id && self->id->deinit_callback) {
             if (!self->id->deinit_callback(self)) {
                 return false;
@@ -295,11 +287,4 @@ rdlock(
     struct ws_object* const obj
 ) {
     pthread_rwlock_rdlock(&obj->rw_lock);
-}
-
-static inline void
-wrlock(
-    struct ws_object* const obj //!< The object to write-lock
-) {
-    pthread_rwlock_wrlock(&obj->rw_lock);
 }

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -37,15 +37,6 @@
  *
  */
 
-/**
- * Alias: `pthread_rwlock_rdlock(&obj->rw_lock);
- */
-static inline void
-rdlock(
-    struct ws_object* const obj //!< The object to read-lock
-);
-
-
 /*
  * Type information
  */
@@ -85,7 +76,7 @@ ws_object_get_type_id(
 ) {
     if (self) {
         ws_object_type_id* id;
-        rdlock(self);
+        ws_object_lock_read(self);
         id = self->id;
         ws_object_unlock(self);
         return id;
@@ -99,7 +90,7 @@ ws_object_get_settings(
 ) {
     if (self) {
         enum ws_object_settings s;
-        rdlock(self);
+        ws_object_lock_read(self);
         s = self->settings;
         ws_object_unlock(self);
         return s;
@@ -191,7 +182,7 @@ ws_object_run(
     if (self) {
         bool b = false;
 
-        rdlock(self);
+        ws_object_lock_read(self);
         if (self->id && self->id->run_callback) {
             b = self->id->run_callback(self);
         }
@@ -281,10 +272,3 @@ ws_object_deinit(
  * static function implementations
  *
  */
-
-static inline void
-rdlock(
-    struct ws_object* const obj
-) {
-    pthread_rwlock_rdlock(&obj->rw_lock);
-}


### PR DESCRIPTION
This PR removes some ws_objectimplementation-internal helper
functions and replaces them with their public equivalents.

Results in less noise in the code.
