### PR TITLE
Remove the init callback for the array type

### DIFF
--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -104,7 +104,11 @@ ws_array_new(void)
     struct ws_array* a = calloc(1, sizeof(*a));
 
     if (a) {
-        ws_object_init(&a->obj);
+        if (0 != ws_array_init(a)) {
+            free(a);
+            return NULL;
+        }
+
         a->obj.settings |= WS_OBJECT_HEAPALLOCED;
     }
 

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -60,7 +60,7 @@ ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY = {
     .supertype  = &WS_OBJECT_TYPE_ID_OBJECT,
     .typestr    = "ws_array",
 
-    .init_callback = init_callback,
+    .init_callback = NULL,
     .deinit_callback = deinit_callback,
 
     .cmp_callback = NULL,

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -84,6 +84,30 @@ ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY = {
  *
  */
 
+int
+ws_array_init(
+    struct ws_array* self
+) {
+    if (!self) {
+        return -EINVAL;
+    }
+
+    self->len = 2; // initialize with two elements
+    self->ary = calloc(self->len, sizeof(*self->ary));
+
+    if (!self->ary) {
+        return -ENOMEM;
+    }
+
+    ws_object_init(&self->obj);
+    self->obj.id = &WS_OBJECT_TYPE_ID_ARRAY;
+
+    self->nused = 0;
+    self->sorted = false;
+
+    return 0;
+}
+
 struct ws_array*
 ws_array_new(void)
 {

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -41,16 +41,6 @@
  */
 
 /**
- * Init callback for array type
- *
- * @return true if initialisation worked, else false
- */
-static bool
-init_callback(
-    struct ws_object* self //!< Array object
-);
-
-/**
  * Deinit callback for array type
  */
 static bool
@@ -295,35 +285,6 @@ ws_array_append(
  *
  *
  */
-
-static bool
-init_callback(
-    struct ws_object* obj
-) {
-    if (obj->id != &WS_OBJECT_TYPE_ID_ARRAY) {
-        return false;
-    }
-
-    struct ws_array* self = (struct ws_array*) obj;
-    if (self) {
-        self->len = 2; // initialize with two elements
-        self->ary = calloc(self->len, sizeof(*self->ary));
-
-        if (!self->ary) {
-            return false;
-        }
-
-        ws_object_init(&self->obj);
-        self->obj.id = &WS_OBJECT_TYPE_ID_ARRAY;
-
-        self->nused = 0;
-        self->sorted = false;
-
-        return true;
-    }
-
-    return false;
-}
 
 static bool
 deinit_callback(

--- a/src/objects/array.h
+++ b/src/objects/array.h
@@ -66,6 +66,18 @@ struct ws_array {
 extern ws_object_type_id WS_OBJECT_TYPE_ID_ARRAY;
 
 /**
+ * Initialize an array object
+ *
+ * @memberof ws_array
+ *
+ * @return zero on success, else negative error number from errno.h
+ */
+int
+ws_array_init(
+    struct ws_array* self //!< Array object
+);
+
+/**
  * Allocate a new, initialized array object
  *
  * @memberof ws_array


### PR DESCRIPTION
This PR removes the init callback for the array type. Init callbacks
do not make sense and we cannot use them as expected, so this is a
bugfix in some way.
