### PR TITLE
Changed monitor creation to sets

### DIFF
--- a/src/compositor/internal_context.h
+++ b/src/compositor/internal_context.h
@@ -28,6 +28,7 @@
 #ifndef __WS_COMPOSITOR_INTERNAL_CONTEXT_H__
 #define __WS_COMPOSITOR_INTERNAL_CONTEXT_H__
 
+#include "objects/set.h"
 #include "compositor/framebuffer_device.h"
 
 /**
@@ -36,7 +37,8 @@
  * This context holds the internal state of the compositor.
  */
 extern struct ws_compositor_context {
-    struct ws_framebuffer_device* fb;
+    struct ws_framebuffer_device* fb; //<! The Framebuffer device
+    struct ws_set monitors; //<! A set of monitors (connected or not)
     struct ws_monitor* conns; //<! A linked list of ws_monitors
 } ws_comp_ctx;
 

--- a/src/compositor/module.h
+++ b/src/compositor/module.h
@@ -32,26 +32,6 @@
 #include <stdlib.h>
 #include <xf86drmMode.h>
 
-/**
- * A connector, which under DRM translates to a Device+Output
- */
-struct ws_monitor {
-    struct ws_monitor* next;
-    int connected; //!< is the monitor connected?
-    uint32_t width; //!< width of the buffer
-    uint32_t height; //!< height of the buffer
-    uint32_t stride; //!< length of a line
-
-    uint32_t size; //!< size of the map
-    uint8_t* map; //!< mapped buffer data
-
-    drmModeModeInfo mode; //!< mode of the monitor
-    uint32_t handle; //!< Handle of the frame buffer
-    uint32_t fb; //!< id of the frame buffer
-    uint32_t conn; //!< id of the connector
-    uint32_t crtc; //!< id of the "monitor"
-    drmModeCrtc* saved_crtc; //!< drm internal datastructure for the crtc
-};
 
 /**
  * Initialise the compositor

--- a/src/compositor/monitor.c
+++ b/src/compositor/monitor.c
@@ -133,7 +133,7 @@ ws_monitor_hash(
     struct ws_object* obj
 ) {
     struct ws_monitor* self = (struct ws_monitor*) obj;
-    return SIZE_MAX / (self->crtc * self->fb_dev->fd);
+    return SIZE_MAX / (self->crtc * self->fb_dev->fd + 1);
 }
 
 static int


### PR DESCRIPTION
This commit changes the monitor list into a set, allowing for an easier
interface.

It changes populate_framebuffer so as to fit into a ws_set_select call. As this
is the way to iterate over the set.

Find connector now also searches using a dummy object instead of iterating
over a linked list.
