### PR TITLE
Move ws monitor buffer to ws buffer

### DIFF
--- a/src/compositor/background_surface.h
+++ b/src/compositor/background_surface.h
@@ -37,6 +37,7 @@ struct ws_image_buffer {
     int height;
     int stride;
     int width;
+    int size;
     void* buffer;
 };
 

--- a/src/compositor/module.c
+++ b/src/compositor/module.c
@@ -280,7 +280,7 @@ find_crtc(
     }
 
     ws_log(&log_ctx, "Could not find suitable Encoder for crtc with dim: %dx%d.",
-            connector->width, connector->height);
+            connector->buffer->width, connector->buffer->height);
     return -ENOENT;
 }
 
@@ -308,6 +308,7 @@ populate_connectors(void) {
             goto insert;
         }
         struct ws_monitor* new_monitor = ws_monitor_new();
+        new_monitor->buffer = ws_image_buffer_new();
         new_monitor->conn = conn->connector_id;
         new_monitor->fb_dev = ws_comp_ctx.fb;
 
@@ -331,11 +332,11 @@ populate_connectors(void) {
         memcpy(&new_monitor->mode, &conn->modes[0],
                 sizeof(new_monitor->mode));
 
-        new_monitor->width = conn->modes[0].hdisplay;
-        new_monitor->height = conn->modes[0].vdisplay;
+        new_monitor->buffer->width = conn->modes[0].hdisplay;
+        new_monitor->buffer->height = conn->modes[0].vdisplay;
 
         ws_log(&log_ctx, "Found a valid connector with %dx%d dimensions.",
-                new_monitor->width, new_monitor->height);
+                new_monitor->buffer->width, new_monitor->buffer->height);
 
         if (find_crtc(res, conn, new_monitor) < 0) {
             ws_log(&log_ctx, "No valid crtcs found");

--- a/src/compositor/monitor.h
+++ b/src/compositor/monitor.h
@@ -54,12 +54,8 @@
 struct ws_monitor {
     struct ws_object obj; //!< Supertype
     int connected; //!< is the monitor connected?
-    uint32_t width; //!< width of the buffer
-    uint32_t height; //!< height of the buffer
-    uint32_t stride; //!< length of a line
 
-    uint32_t size; //!< size of the map
-    uint8_t* map; //!< mapped buffer data
+    struct ws_image_buffer* buffer; //!< The frame buffer
 
     struct ws_framebuffer_device* fb_dev; //!< Framebuffer Device
     drmModeModeInfo mode; //!< mode of the monitor


### PR DESCRIPTION
This moves the buffer field of the `ws_monitor` struct into a `ws_image_buffer`.
