### PR TITLE
Fix refcounting/deallocation mechanism for stack allocated objects

### DIFF
--- a/src/compositor/framebuffer_device.c
+++ b/src/compositor/framebuffer_device.c
@@ -86,6 +86,7 @@ ws_framebuffer_device_new(
     struct ws_framebuffer_device* tmp = calloc(1, sizeof(*tmp));
     ws_object_init((struct ws_object*)tmp);
     tmp->obj.id = &WS_OBJECT_TYPE_ID_FRAMEBUFFER_DEVICE;
+    tmp->obj.settings |= WS_OBJECT_HEAPALLOCED;
     tmp->fd = open(path, O_RDWR | O_CLOEXEC);
 
     if (tmp->fd < 0) {

--- a/src/compositor/monitor.c
+++ b/src/compositor/monitor.c
@@ -88,6 +88,7 @@ ws_monitor_new(
     struct ws_monitor* tmp = calloc(1, sizeof(*tmp));
     ws_object_init((struct ws_object*)tmp);
     tmp->obj.id = &WS_OBJECT_TYPE_ID_MONITOR;
+    tmp->obj.settings |= WS_OBJECT_HEAPALLOCED;
     return tmp;
 }
 

--- a/src/compositor/wayland_buffer.c
+++ b/src/compositor/wayland_buffer.c
@@ -185,6 +185,7 @@ ws_wayland_buffer_new(
         goto cleanup;
     }
     w->buf.obj.id = &buffer_type.type;
+    w->buf.obj.settings |= WS_OBJECT_HEAPALLOCED;
 
     return w;
 

--- a/src/objects/array.c
+++ b/src/objects/array.c
@@ -91,6 +91,7 @@ ws_array_new(void)
 
     if (a) {
         ws_object_init(&a->obj);
+        a->obj.settings |= WS_OBJECT_HEAPALLOCED;
     }
 
     return a;

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -57,7 +57,7 @@ ws_object_new(
 
     if (o) {
         o->id = &WS_OBJECT_TYPE_ID_OBJECT;
-        o->settings = WS_OBJ_NO_SETTINGS;
+        o->settings = WS_OBJECT_HEAPALLOCED;
         pthread_rwlock_init(&o->rw_lock, NULL);
         pthread_rwlock_init(&o->ref_counting.rwl, NULL);
     }

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -128,7 +128,7 @@ enum ws_object_settings {
     WS_OBJ_NO_SETTINGS = 0,
     WS_OBJ_CONST            = 1 << 0,
     WS_OBJ_SELF_DESTROYING  = 1 << 1,
-    WS_OBJECT_STACKALLOCED  = 1 << 2,
+    WS_OBJECT_HEAPALLOCED   = 1 << 2,
     WS_OBJECT_LOCKABLE      = 1 << 3,
 };
 

--- a/src/objects/set.c
+++ b/src/objects/set.c
@@ -125,6 +125,7 @@ ws_set_new(void)
 
     if (set) {
         ws_set_init(set);
+        set->obj.settings |= WS_OBJECT_HEAPALLOCED;
     }
 
     return set;

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -99,6 +99,7 @@ ws_string_new(void)
 
     if (wss) {
         ws_string_init(wss);
+        wss->obj.settings |= WS_OBJECT_HEAPALLOCED;
     }
 
     return wss;

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -106,6 +106,7 @@ ws_wayland_obj_new(
     }
 
     if (0 == ws_wayland_obj_init(w, r)) {
+        w->obj.settings |= WS_OBJECT_HEAPALLOCED;
         return w;
     }
 


### PR DESCRIPTION
This is done by
- introducing a flag denoting ojects allocated on the heap
- Setting that flag in each existing derived "class".
