### PR TITLE
Fix order of inclusions in surface.c

### DIFF
--- a/src/compositor/surface.c
+++ b/src/compositor/surface.c
@@ -26,8 +26,10 @@
  */
 
 #include <malloc.h>
-#include <wayland-server-protocol.h>
+
+// wayland-server.h has to be included before wayland-server-protocol.h
 #include <wayland-server.h>
+#include <wayland-server-protocol.h>
 
 #include "compositor/surface.h"
 #include "util/wayland.h"


### PR DESCRIPTION
Fixes an issue which seems to surface on Arch Linux.
