### PR TITLE
Fixed ws_set_get selecting the opposite

### DIFF
--- a/src/objects/set.c
+++ b/src/objects/set.c
@@ -227,7 +227,7 @@ ws_set_get(
 //     if (self && other) {
 //         return r_set_is_subset(self->set, other->set);
 //     }
-// 
+//
 //     return false;
 // }
 
@@ -284,7 +284,7 @@ cmp_objects(
     struct ws_object* o1 = (struct ws_object*) a;
     struct ws_object* o2 = (struct ws_object*) b;
 
-    return ws_object_cmp(o1, o2);
+    return !ws_object_cmp(o1, o2);
 }
 
 static bool


### PR DESCRIPTION
This PR fixes a bug in ws_set_get.

Libreset expects a boolean return value, but we give it a POSIX style return value. This inverts the logic.
