### PR TITLE
Use "__typeof__" instead of "typeof" for getref() macro

### DIFF
--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -51,7 +51,8 @@
  * Convenience macros
  *
  */
-#define getref(obj_) ((typeof(obj_)) ws_object_getref((struct ws_object*) (obj_)))
+#define getref(obj_) ((__typeof__(obj_)) \
+                     ws_object_getref((struct ws_object*) (obj_)))
 
 /*
  * Type names


### PR DESCRIPTION
This is a very simple fix meant to prevent compiler warnings.
Still uses gcc/clang extensions...
