### PR TITLE
Add logging calls in ws_object implementation

### DIFF
--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -128,6 +128,8 @@ ws_object_init(
     struct ws_object* self
 ) {
     if (self) {
+        ws_log(&log_ctx, "Initializing: %p", self);
+
         self->settings = WS_OBJ_NO_SETTINGS;
 
         pthread_rwlock_init(&self->rw_lock, NULL);

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -339,6 +339,8 @@ ws_object_cmp(
     struct ws_object const* o1,
     struct ws_object const* o2
 ) {
+    ws_log(&log_ctx, "Comparing: %p <=> %p", o1, o2);
+
     if ((o1 == NULL) ^ (o2 == NULL)) {
         return (o1 != NULL) ? -1 : 1;
     }

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -216,6 +216,8 @@ ws_object_run(
         return false;
     }
 
+    ws_log(&log_ctx, "Running: %p (%s)", self, self->id->typestr);
+
     ws_object_type_id* type = self->id;
     while (!type->run_callback) {
         if (type == &WS_OBJECT_TYPE_ID_OBJECT) {

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -65,6 +65,8 @@ ws_object_new(
         return NULL;
     }
 
+    ws_log(&log_ctx, "Allocating");
+
     struct ws_object* o = calloc(1, s);
 
     if (o) {

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -242,6 +242,8 @@ ws_object_hash(
         return false;
     }
 
+    ws_log(&log_ctx, "Hashing: %p (%s)", self, self->id->typestr);
+
     ws_object_type_id* type = self->id;
     while (!type->hash_callback) {
         // we hit the basic object type, which is totally abstract

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -317,6 +317,9 @@ ws_object_deinit(
     if (self) {
         ws_object_lock_write(self);
         if (self->id && self->id->deinit_callback) {
+            ws_log(&log_ctx, "Deinitializing: %p (%s)",
+                    self, self->id->typestr);
+
             if (!self->id->deinit_callback(self)) {
                 return false;
             }

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -196,6 +196,9 @@ ws_object_dump_state(
     if (self) {
         ws_object_lock_read(self);
         if (self->id && self->id->dump_callback) {
+            ws_log(&log_ctx, "Dumping object state: %p (%s)",
+                    self, self->id->typestr);
+
             self->id->dump_callback(ctx, self);
             res = true;
         }

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -30,6 +30,11 @@
 #include <pthread.h>
 
 #include "objects/object.h"
+#include "logger/module.h"
+
+static struct ws_logger_context log_ctx = {
+    .prefix = "[Object]",
+};
 
 /*
  *

--- a/tests/check/objects/ws_object/CMakeLists.txt
+++ b/tests/check/objects/ws_object/CMakeLists.txt
@@ -2,6 +2,8 @@ find_package(Threads REQUIRED)
 
 set(TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/src/objects/object.c
+    ${PROJECT_SOURCE_DIR}/src/logger/module.c
+    ${PROJECT_SOURCE_DIR}/src/util/cleaner.c
     PARENT_SCOPE)
 
 set(TEST_LIBRARIES


### PR DESCRIPTION
This PR adds a few calls to ws_log() in the object type
implementation.
