### PR TITLE
Add command list

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Building the waysome exetuable
 #
 
+add_subdirectory(command)
+
 #
 # Set include directories
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_definitions(
 #
 set(SOURCE_FILES
     command/command.c
+    command/list.c
     compositor/background_surface.c
     compositor/buffer.c
     compositor/framebuffer_device.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_definitions(
 # into waysome.
 #
 set(SOURCE_FILES
+    command/arithmetical.c
     command/command.c
     command/list.c
     compositor/background_surface.c

--- a/src/command/.gitignore
+++ b/src/command/.gitignore
@@ -1,0 +1,3 @@
+# Ignore files we generated
+list.c
+

--- a/src/command/.gitignore
+++ b/src/command/.gitignore
@@ -1,3 +1,4 @@
 # Ignore files we generated
 list.c
+arithmetical.h
 

--- a/src/command/CMakeLists.txt
+++ b/src/command/CMakeLists.txt
@@ -21,6 +21,7 @@
 # List of command files
 #
 set(WS_COMMAND_FILES
+    arithmetical.commands
 )
 
 

--- a/src/command/CMakeLists.txt
+++ b/src/command/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+#
+# List of command files
+#
+set(WS_COMMAND_FILES
+)
+
+#
+# Process all command definition files
+#
+foreach(COMMAND_FILE IN LISTS WS_COMMAND_FILES)
+endforeach()
+

--- a/src/command/CMakeLists.txt
+++ b/src/command/CMakeLists.txt
@@ -1,3 +1,21 @@
+#
+# Command list generation setup
+#
+# So this is how it works:
+# This directory holds "*.commands" files, through which you can add commands
+# in a relatively simple way.
+#
+# Each line of such a file contains the command's name, a semicolon and the
+# type of the command ("regular" or "special").
+# For each line, a command declaration will be generated and put into a header
+# with the same basename as the command name.
+# The command functions declared in the generated header should be implemented
+# in the corresponding source file.
+#
+# All the commands will be added to the generated command list in list.c,
+# making them globally available through the ws_command_get() method.
+#
+
 
 #
 # List of command files
@@ -5,9 +23,59 @@
 set(WS_COMMAND_FILES
 )
 
+
 #
 # Process all command definition files
 #
 foreach(COMMAND_FILE IN LISTS WS_COMMAND_FILES)
+    file(STRINGS ${COMMAND_FILE} COMMANDS)
+    set(COMMAND_DECLS)
+
+    foreach(COMMAND IN LISTS COMMANDS)
+        # Get command name and type
+        list(GET COMMAND 0 TMP)
+        string(STRIP "${TMP}" COMMAND_NAME)
+
+        list(GET COMMAND 1 TMP)
+        string(STRIP "${TMP}" COMMAND_TYPE)
+
+        # Collect commands
+        list(APPEND WS_COMMANDS "${COMMAND_NAME} ${COMMAND_TYPE}")
+
+        # Generate command declarations
+        set(COMMAND_DECLS
+            "${COMMAND_DECLS}\nDECLARE_CMD_${COMMAND_TYPE}(${COMMAND_NAME});"
+        )
+    endforeach()
+
+    # Generate header file for commands
+    string(REPLACE ".commands" ".h" COMMAND_HEADER ${COMMAND_FILE})
+    configure_file("declarations.h.in" ${COMMAND_HEADER})
+
+    # Add to header list
+    set(HEADER_INCLUSION "${HEADER_INCLUSION}\n#include \"${COMMAND_HEADER}\"")
 endforeach()
+
+#
+# Sort the commands alphabetially so we can perform a binary search
+#
+if(DEFINED WS_COMMANDS)
+    list(SORT WS_COMMANDS)
+endif()
+
+#
+# Generate the command list source
+#
+set(LIST_BODY)
+foreach(COMMAND IN LISTS WS_COMMANDS)
+    # Get command name and type
+    string(REPLACE " " ";" COMMAND_PARTS ${COMMAND})
+    list(GET COMMAND_PARTS 0 COMMAND_NAME)
+    list(GET COMMAND_PARTS 1 COMMAND_TYPE)
+
+    set(LIST_BODY
+        "${LIST_BODY}\n    COMMAND(${COMMAND_NAME}, ${COMMAND_TYPE})"
+    )
+endforeach()
+configure_file("list.c.in" "list.c")
 

--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -1,0 +1,61 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "command/arithmetical.h"
+
+int
+ws_builtin_cmd_add(
+    union ws_value_union* args
+) {
+    //!< @todo: implement
+    return 0;
+}
+
+int
+ws_builtin_cmd_sub(
+    union ws_value_union* args
+) {
+    //!< @todo: implement
+    return 0;
+}
+
+int
+ws_builtin_cmd_mul(
+    union ws_value_union* args
+) {
+    //!< @todo: implement
+    return 0;
+}
+
+int
+ws_builtin_cmd_div(
+    union ws_value_union* args
+) {
+    //!< @todo: implement
+    return 0;
+}
+

--- a/src/command/arithmetical.commands
+++ b/src/command/arithmetical.commands
@@ -1,0 +1,4 @@
+add;regular
+sub;regular
+mul;regular
+div;regular

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -32,7 +32,7 @@
 
 // forward declarations
 struct ws_command_processor;
-struct ws_value;
+union ws_value_union;
 
 /**
  * A command argument
@@ -68,7 +68,7 @@ struct ws_command_args {
  * Functions of this type will implement commands which may be use in
  * transactions.
  */
-typedef int (*ws_regular_command_func)(struct ws_value*);
+typedef int (*ws_regular_command_func)(union ws_value_union*);
 
 /**
  * Function type for special commands

--- a/src/command/declarations.h.in
+++ b/src/command/declarations.h.in
@@ -1,0 +1,36 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __WS_COMMAND_DECLARATION_H__
+#define __WS_COMMAND_DECLARATION_H__
+
+#include "list.h"
+
+${COMMAND_DECLS}
+
+#endif // __WS_COMMAND_DECLARATION_H__
+

--- a/src/command/list.c.in
+++ b/src/command/list.c.in
@@ -1,0 +1,35 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "list.h"
+
+${HEADER_INCLUSION}
+
+struct ws_command ws_command_list[] = {
+${LIST_BODY}
+};
+

--- a/src/command/list.h
+++ b/src/command/list.h
@@ -1,0 +1,54 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __WS_COMMAND_LIST_H__
+#define __WS_COMMAND_LIST_H__
+
+#include "command/command.h"
+
+#define DECLARE_CMD_regular(name_) int ws_builtin_cmd_##name_(\
+    union ws_value_union*\
+)
+
+#define DECLARE_CMD_special(name_) int ws_builtin_cmd_##name_(\
+    struct ws_command_processor*,\
+    struct ws_command_args*\
+)
+
+#define COMMAND(name_, type_) {\
+    .name = #name_,\
+    .command_type = type_,\
+    .func.type_ = ws_builtin_cmd_##name_,\
+},
+
+/**
+ * List holding all the commands in alphabetical order
+ */
+extern struct ws_command ws_command_list[];
+
+#endif // __WS_COMMAND_LIST_H__
+

--- a/src/values/union.h
+++ b/src/values/union.h
@@ -1,0 +1,44 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "values/bool.h"
+#include "values/int.h"
+#include "values/nil.h"
+#include "values/string.h"
+#include "values/value.h"
+
+/**
+ * Union for all the value types in existence
+ */
+union ws_value_union {
+    struct ws_value         value;  //!< plain value
+    struct ws_value_nil     nil;    //!< nil value
+    struct ws_value_bool    bool;   //!< bool value
+    struct ws_value_int     int;    //!< int value
+    struct ws_value_string  string; //!< string value
+};
+


### PR DESCRIPTION
This PR introduces template files for the the command list and a build environment setup to acutally generate it. It takes care of the list being alphabetically ordered.

One thing I'm still unsure about is whether I should add a source file to the `SOURCE_FILES` for each header generated. It would mean that you don't have to do it yourself, but it would also _force_ you to have those sources.
