### PR TITLE
Fix void cast in wayland_shell.c

### DIFF
--- a/src/compositor/wayland_shell.c
+++ b/src/compositor/wayland_shell.c
@@ -149,7 +149,7 @@ create_shell_surface_cb(
     struct ws_surface* internal_surface = ws_surface_from_resource(surface);
 
     // we create the surface and leave the destruction to the attached resource
-    (void*) ws_shell_surface_new(client, internal_surface, serial);
+    (void) ws_shell_surface_new(client, internal_surface, serial);
 }
 
 


### PR DESCRIPTION
This was a typo, which causes clang based builds to fail if `HARD_MODE=ON` (and causes a nasty warning if we are not in hard mode).
