### PR TITLE
Remove unneccessary check from ws_connbuf_append

### DIFF
--- a/src/connection/connbuf.c
+++ b/src/connection/connbuf.c
@@ -88,10 +88,6 @@ ws_connbuf_append(
     struct ws_connbuf* self,
     size_t amount
 ) {
-    if (amount == 0) {
-        return -EINVAL;
-    }
-
     if (!self->blocked) {
         return -EINTR;
     }


### PR DESCRIPTION
In some cases, you want to append 0 bytes to unblock the buffer.
