### PR TITLE
Fix ws_transaction_command_list

### DIFF
--- a/src/objects/message/transaction.h
+++ b/src/objects/message/transaction.h
@@ -50,7 +50,7 @@ enum ws_transaction_flags {
  */
 struct ws_transaction_command_list {
     size_t n; //!< @protected length of the command array
-    struct ws_command* cmds; //!< @protected Command objects
+    struct ws_statement* statements; //!< @protected Statements of the transaction
 };
 
 /**


### PR DESCRIPTION
Should be obvious. We want statements, not commands. Statements are command invocations.
Targets #233.
