### PR TITLE
Fixed segfault in ws_monitor_publish

### DIFF
--- a/src/compositor/module.c
+++ b/src/compositor/module.c
@@ -459,7 +459,6 @@ populate_connectors(void) {
 
 insert:
         new_monitor->id = i;
-        ws_monitor_publish(new_monitor);
         ws_set_insert(&ws_comp_ctx.monitors, (struct ws_object*)new_monitor);
     }
     return 0;

--- a/src/compositor/monitor.c
+++ b/src/compositor/monitor.c
@@ -157,6 +157,7 @@ bind_output(
 
     if (!monitor->resource) {
         ws_log(&log_ctx, LOG_ERR, "Wayland couldn't create object");
+        return;
     }
 
     // We don't set an implementation, instead we just set the data
@@ -305,6 +306,12 @@ ws_monitor_set_mode_with_id(
     if (!self->current_mode) {
         return;
     }
+
+    if (!self->resource) {
+        ws_log(&log_ctx, LOG_DEBUG, "Did not publish mode.");
+        return;
+    }
+    ws_log(&log_ctx, LOG_DEBUG, "Published a mode.");
 
     // Let's tell wayland that this is the current mode!
     wl_output_send_mode((struct wl_resource*) self->resource,


### PR DESCRIPTION
This was a misunderstanding (due to no documentation) and it seems that
monitor->resource will only be created once a client requests it, this commit
removes it from the compositor module.
