### PR TITLE
Update JSON API documentation

### DIFF
--- a/doc/user/api/json.md
+++ b/doc/user/api/json.md
@@ -29,15 +29,21 @@ the arguments of the command:
 
     { "add": [1, 2] }
 
-The arguments are
+The value can be a
 
-* Integers, to tell waysome to use N positions from the stack
+* Integer, to tell waysome to use N positions from the stack
 
-* Integers in an array, to refer to positions on the execution stack, whereas
-  positive values are positions in the stack from the _bottom_ to the _top_ of
-  the stack and negative values are from the _top_ to the _bottom_ of the stack.
-
-* Objects, to pass constants to the command.
+* Array, for arguments to the command, whereas
+- "null" is NIL
+- "true"/"false" as booleans
+- Integers as integers
+- Doubles as doubles (not supported yet)
+- Strings as strings
+- Arrays to specify a set
+- An object: '{ "pos": 1 }' to refer to a position on the stack (first in this
+  case)
+- An object: '{ "name": "a name", "value": <value> }' for a named value, whereas
+  the name is a string and the value can be one out of this list.
 
 Of course you can mix objects and integers in the array, if the related command
 takes them.
@@ -48,25 +54,13 @@ For example:
 
 Pop four positions from the stack,
 
-    { "pop": [-1] }
+    { "pop": [{ "pos": -1 }] }
 
 means "Pop the first value on top of the stack", but
 
-    { "pop": [ { "int": 1 } ] }
+    { "pop": [ 1 ] }
 
 does not make sense, as the argument to "pop" is a constant.
-
-As the previous example shows, the arguments can be constants. These constants
-are described using another JSON object, whereas the _key_ is the _type_ and the
-_value_ is the _value_. Possible types are
-
-* "nil", whereas the _value_ of the object should then be "null"
-* "bool", whereas the _value_ of the object should then be one of "true",
-  "false" (as JSON literals), 0 or 1
-* "int", whereas the _value_ of the object is a number
-* "string", whereas the _value_ of the object should be a string
-
-More values to come.
 
 ## Summary
 
@@ -78,9 +72,9 @@ containing a integer value 3.
     {
         "UID": "my awesome uid",
         "commands": [
-            { "push": [ { "int": 1 } ] },
-            { "push": [ { "int": 2 } ] },
-            { "add": [ -1, -2 ] }
+            { "push": [ 1 ] },
+            { "push": [ 2 ] },
+            { "add": [ { "pos": -1 }, { "pos": -2 } ] }
         ]
     }
 

--- a/src/serialize/json/statemachine.md
+++ b/src/serialize/json/statemachine.md
@@ -109,37 +109,31 @@ command argument parsing step, which is described in another state chart.
 
 #### Command Argument parsing
 
-An "indirect" value is a simple integer in the command array, which refers to a
-position on the execution stack. The parsing here is fairly easy: The moment
-when the number is recognized by the yajl library, we are in the argument array
-parsing state. The number gets recognized and we do not change the state, as the
-parsing for that argument is finished immediately.
+There are two possible ways to pass something to a command using arguments:
+Via the stack and positions on the stack or directly by specifying the arguments
+in the array.
 
-So, indirect value parsing is relatively simple, whereas the direct value types
-are a bit more complex to parse. They include type information and
-data information, whereas the type information is a string (the key of an
-object) and the value of combined with that key is the value of the argument.
-E.G.:
+Parsing arguments passed via the array is simple, you only have to check if
+you are in the argument array or not and push the appropriate argument to the
+command. Stack positions have to be passed through an object, though. So do more
+complex objects as named values (sets can be passed as arrays).
 
-    { "int" : 1 }
-    { "string" : "Hello World" }
-
-(No claim for correct key names here)
-
-So, the state chart for the combined argument parsing looks like this:
-
-                                "{"
-    Command Arguments -------------------> Command Argument Direct value
-        ^           |                                   |
-        |           | <number>                          |
-        |<----------+                                   |
-        |                                               |
-    "}" |                                               | <typename>
-        |                                               |
-        |                                               |
-        |                                               |
-        |                                               v
-    Command Arg Direct Value <------------ Command Arg Direct Value Type
+    Command Arguments ------+-----------------------+
+        ^   ^               | <nil>,                |
+        |   |               | <boolean>,            |
+        |   |               | <integer>,            |
+        |   |               | <double>,             |
+        |   |               | <string>              | "{"
+        |   +---------------+                       |
+        |                                           v
+        |                                   Argument object
+        |                                           |
+        |                   +-----------------------+
+        |                   |                       |
+        |                   | "pos"*                | "named"*
+        |                   |                       |
+        |   <number>        v                       v
+        +-------------- Argument: position      Argument: Named val
 
 (*) The used strings are as constants in the code and are defined in a central
 place.


### PR DESCRIPTION
Updates include:

```
* We use constants as arguments in a overhead free way now, so
  integers are really integers and if one wants to specify stack
  positions, a special json object has to be used.

* Removal of documentation sections saying something else.

* Note that doubles are not yet supported.
```

---

The above is also in the commit message (as this is a one-commit PR).
