### PR TITLE
Extend statement initializer by the command name

### DIFF
--- a/src/command/statement.c
+++ b/src/command/statement.c
@@ -27,6 +27,7 @@
 
 #include <errno.h>
 
+#include "command/command.h"
 #include "command/statement.h"
 #include "values/value.h"
 
@@ -59,9 +60,14 @@ __ws_nonnull__(1)
 
 int
 ws_statement_init(
-    struct ws_statement* self
+    struct ws_statement* self,
+    char const* name
 ) {
-    self->command = NULL;
+    self->command = ws_command_get(name);
+    if (!self->command) {
+        return -EINVAL;
+    }
+
     self->args.num = 0;
     self->args.vals = NULL;
     return 0;

--- a/src/command/statement.h
+++ b/src/command/statement.h
@@ -84,9 +84,10 @@ struct ws_statement {
  */
 int
 ws_statement_init(
-    struct ws_statement* self //!< statement to initialize
+    struct ws_statement* self, //!< statement to initialize
+    char const* name //!< name of the command to initialize the statement with
 )
-__ws_nonnull__(1)
+__ws_nonnull__(1, 2)
 ;
 
 /**


### PR DESCRIPTION
I realized that it makes sense to initialize the command using a name. It's ok for the WIP JSON deserializer, since the parser wil see the command name before it sees the arguments _always_. Other formats should take care to have the command name before the argument list, which should be the case anyway.

This has two concrete benefits:
- The parsers don't need to know anything about `command/command.h`.
- Statement construction get's even easier.
