### PR TITLE
Add arithmetical commands

### DIFF
--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -91,7 +91,22 @@ int
 ws_builtin_cmd_mul(
     union ws_value_union* args
 ) {
-    //!< @todo: implement
+    intmax_t prod = 1;
+    intmax_t val;
+    union ws_value_union* it;
+
+    // iterate over all the arguments, checking whether they are ints
+    ITERATE_ARGS_TYPE(it, args, val, int) {
+        prod *= val;
+    }
+
+    if (!AT_END(it)) {
+        // Arrr! We must've hit something, captn!
+        return -EINVAL;
+    }
+
+    ws_value_union_reinit(args, WS_VALUE_TYPE_INT);
+    ws_value_int_set(&args->int_, prod);
     return 0;
 }
 

--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -114,6 +114,23 @@ int
 ws_builtin_cmd_div(
     union ws_value_union* args
 ) {
-    //!< @todo: implement
+    if (ws_value_get_type(&args->value) != WS_VALUE_TYPE_INT ||
+            ws_value_get_type(&args[1].value) != WS_VALUE_TYPE_INT) {
+        return -EINVAL;
+    }
+
+    if (ws_value_get_type(&args[2].value) != WS_VALUE_TYPE_NONE) {
+        return -E2BIG;
+    }
+
+    intmax_t tmp_dividend = ws_value_int_get(&args->int_);
+    intmax_t tmp_divisor = ws_value_int_get(&args[1].int_);
+
+    if (tmp_divisor == 0) {
+        return -EFAULT;
+    }
+
+    ws_value_int_set(&args->int_, tmp_dividend / tmp_divisor);
+
     return 0;
 }

--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -39,7 +39,6 @@ int
 ws_builtin_cmd_add(
     union ws_value_union* args
 ) {
-
     intmax_t sum = 0;
     intmax_t val;
     union ws_value_union* it;

--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -62,7 +62,28 @@ int
 ws_builtin_cmd_sub(
     union ws_value_union* args
 ) {
-    //!< @todo: implement
+    intmax_t sum = 0;
+    intmax_t val;
+    union ws_value_union* it;
+
+    if (ws_value_get_type(&args->value) != WS_VALUE_TYPE_INT) {
+        return -EINVAL;
+    }
+
+    sum = ws_value_int_get(&args[0].int_);
+
+    // iterate over all the arguments, checking whether they are ints
+    ITERATE_ARGS_TYPE(it, args + 1, val, int) {
+        sum -= val;
+    }
+
+    if (!AT_END(it)) {
+        // Arrr! We must've hit something, captn!
+        return -EINVAL;
+    }
+
+    ws_value_union_reinit(args, WS_VALUE_TYPE_INT);
+    ws_value_int_set(&args->int_, sum);
     return 0;
 }
 

--- a/src/command/arithmetical.c
+++ b/src/command/arithmetical.c
@@ -30,7 +30,10 @@
 
 #include "command/arithmetical.h"
 #include "command/util.h"
+#include "values/int.h"
 #include "values/union.h"
+#include "values/value.h"
+#include "values/value_type.h"
 
 int
 ws_builtin_cmd_add(
@@ -79,4 +82,3 @@ ws_builtin_cmd_div(
     //!< @todo: implement
     return 0;
 }
-


### PR DESCRIPTION
Targets #267

---

I know that this PR will start a shitstorm, even if I tell you:
Calm down before reviewing this! I didn't do that to piss you
off or something!

---

So, here is why I wrote these implementations the way I did:
1. The code in `do_integral_arithmetic()` would be duplicated
   four times when writing it the other way.
2. I didn't use macros. Macros would be the alternative to this,
   but I know that some of you guys hate large macro foo, and this
   would clearly end up beeing a big shitload of macro foo!
3. I wonder how this will get optimized and whether the compiler
   is intelligent enough to optimize this into single functions.
   Probably it is not, but maybe it does some crazy optimization
   here we don't know yet.

---

I'm not pissed off or something if this gets rejected, but I
would like to have a calm and premeditated discussion about it,
without bad words and the like!
