### PR TITLE
Fix argument preparation in action processor

### DIFF
--- a/src/action/manager.c
+++ b/src/action/manager.c
@@ -152,7 +152,7 @@ run_transaction(
     }
 
     // create the return message from the transaction and the value
-    struct ws_value* value = ws_processor_stack_value_at(&stack, -1);
+    struct ws_value* value = ws_processor_stack_value_at(&stack, -1, NULL);
     retval = (struct ws_reply*) ws_value_reply_new(transaction, value);
 
     // cleanup

--- a/src/action/processor.c
+++ b/src/action/processor.c
@@ -169,7 +169,6 @@ ws_processor_prepare_args(
     union ws_value_union* top = ws_processor_stack_top(stack);
     size_t argc = args->num;
 
-    //!< @todo optimize for if arguments already are in the right position
     {
         int res = ws_processor_stack_push(stack, argc);
         if (res < 0) {

--- a/src/action/processor.c
+++ b/src/action/processor.c
@@ -188,7 +188,8 @@ ws_processor_prepare_args(
             break;
 
         case indirect:
-            src = ws_processor_stack_value_at(stack, cur_arg->arg.pos);
+            src = ws_processor_stack_value_at(stack, cur_arg->arg.pos,
+                                              &top->value);
             break;
         }
 
@@ -231,7 +232,7 @@ exec_regular(
     } else {
         // the parameters are given implicitely
         top = (union ws_value_union*)
-              ws_processor_stack_value_at(stack, -(args->num));
+              ws_processor_stack_value_at(stack, -(args->num), NULL);
     }
 
     // we somehow ended up with a bad stack

--- a/src/action/processor_stack.c
+++ b/src/action/processor_stack.c
@@ -180,12 +180,20 @@ ws_processor_stack_bottom(
 struct ws_value*
 ws_processor_stack_value_at(
     struct ws_processor_stack* self,
-    ssize_t pos
+    ssize_t pos,
+    struct ws_value* opttop
 ) {
+    size_t top = self->top;
+
+    // if `opttop` is `NULL`, we want to use the value we have
+    if (opttop) {
+        top = ((union ws_value_union*) opttop) - self->data;
+    }
+
     // determine whether pos of from top or bottom and calculate
     if (pos >= 0) {
         // check whether the position is valid
-        if ((size_t) pos >= self->top) {
+        if ((size_t) pos >= top) {
             return NULL;
         }
 
@@ -193,10 +201,10 @@ ws_processor_stack_value_at(
     }
 
     // check whether the position is valid
-    if ((size_t) (-pos) > self->top) {
+    if ((size_t) (-pos) > top) {
         return NULL;
     }
-    return &(self->data + self->top + pos)->value;
+    return &(self->data + top + pos)->value;
 }
 
 size_t

--- a/src/action/processor_stack.h
+++ b/src/action/processor_stack.h
@@ -147,7 +147,8 @@ __ws_nonnull__(1)
 struct ws_value*
 ws_processor_stack_value_at(
     struct ws_processor_stack* self, //!< the stack
-    ssize_t pos //!< position of value
+    ssize_t pos, //!< position of value
+    struct ws_value* top //!< top to use (`NULL` for internal top)
 )
 __ws_nonnull__(1)
 ;

--- a/src/command/control.c
+++ b/src/command/control.c
@@ -60,7 +60,7 @@ ws_builtin_cmd_jump(
         struct ws_value* val;
         switch(arg->type) {
         case indirect: // the value must be extracted from the stack
-            val = ws_processor_stack_value_at(proc->stack, arg->arg.pos);
+            val = ws_processor_stack_value_at(proc->stack, arg->arg.pos, NULL);
             break;
 
         case direct: // the value is passed directly


### PR DESCRIPTION
The action processor did use the new top for indirect arguments, when it should have used the old one.
