### PR TITLE
Fix the stack top fetching in ws_processor_prepare_args()

### DIFF
--- a/src/action/processor.c
+++ b/src/action/processor.c
@@ -166,7 +166,6 @@ ws_processor_prepare_args(
     struct ws_processor_stack* stack,
     struct ws_command_args const* const args
 ) {
-    union ws_value_union* top = ws_processor_stack_top(stack);
     size_t argc = args->num;
 
     {
@@ -175,6 +174,8 @@ ws_processor_prepare_args(
             return res;
         }
     }
+
+    union ws_value_union* top = ws_processor_stack_top(stack) - argc;
 
     // iterate over all the arguments and assemble the stack
     while (argc--) {


### PR DESCRIPTION
This patch fixes the stack top fetching in the
ws_processor_prepare_args() function. The problem was that the pushing
to the stack changes the stack and _realloc()_s it, if required. That
causes the stack object to be located in another position, which caused
everything to fail.

Suggested-by: Julian Ganz julian.ganz@hs-furtwangen.de
