### PR TITLE
Fix type of buffer var

### DIFF
--- a/src/values/union.c
+++ b/src/values/union.c
@@ -57,7 +57,7 @@ ws_value_union_init_from_val(
     case WS_VALUE_TYPE_INT:
         ws_value_int_init(&dest->int_);
         {
-            uint32_t buf = ws_value_int_get((struct ws_value_int*) src);
+            intmax_t buf = ws_value_int_get((struct ws_value_int*) src);
             return ws_value_int_set(&dest->int_, buf);
         }
 


### PR DESCRIPTION
If we internally use intmax_t, but the buffer used for transmission is
an uin32_t, we end up with completely different values for negative
and/or big numbers.
