### PR TITLE
Ignore generated string.h

### DIFF
--- a/src/command/.gitignore
+++ b/src/command/.gitignore
@@ -4,4 +4,5 @@ arithmetical.h
 binary.h
 control.h
 logical.h
+string.h
 


### PR DESCRIPTION
This PR fixes a minor anoyance by adding a generated header to the gitignore file.
