### PR TITLE
Redefine ws_object_deinit

### DIFF
--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -417,10 +417,8 @@ ws_object_unlock(
  * @warning It is not save to use the object after this method was called on it.
  *
  * @warning Should only be called for objects which are allocated on the stack.
- *
- * @return true on success, else false
  */
-bool
+void
 ws_object_deinit(
     struct ws_object* self //!< The object
 )

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -423,7 +423,9 @@ ws_object_unlock(
 bool
 ws_object_deinit(
     struct ws_object* self //!< The object
-);
+)
+__ws_nonnull__(1)
+;
 
 /**
  * Get an attribute of an object

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -50,7 +50,7 @@ START_TEST (test_object_init) {
     memset(&o, 0, sizeof(o));
 
     ck_assert(ws_object_init(&o));
-    ck_assert(ws_object_deinit(&o));
+    ws_object_deinit(&o);
 }
 END_TEST
 

--- a/tests/check/objects/ws_set/test.c
+++ b/tests/check/objects/ws_set/test.c
@@ -176,7 +176,7 @@ static void
 test_set_teardown(void)
 {
     ck_assert(set != NULL);
-    ck_assert(true == ws_object_deinit(&set->obj));
+    ws_object_deinit(&set->obj);
     free(set);
     set = NULL;
     ck_assert(set == NULL);
@@ -193,7 +193,7 @@ test_set_teardown_objs(void)
 
     for (i = N_TEST_OBJS - 1; i; --i) {
         ck_assert(TEST_OBJS[i] != NULL);
-        ck_assert(true == ws_object_deinit(TEST_OBJS[i]));
+        ws_object_deinit(TEST_OBJS[i]);
 
         free(TEST_OBJS[i]);
 
@@ -204,10 +204,10 @@ test_set_teardown_objs(void)
 static void
 test_set_teardown_sets(void)
 {
-    ck_assert(true == ws_object_deinit((struct ws_object*) set_a));
+    ws_object_deinit((struct ws_object*) set_a);
     set_a = NULL;
 
-    ck_assert(true == ws_object_deinit((struct ws_object*) set_b));
+    ws_object_deinit((struct ws_object*) set_b);
     set_b = NULL;
 
     test_set_teardown_objs();
@@ -226,7 +226,7 @@ END_TEST
 
 START_TEST (test_set_init_deinit) {
     ck_assert(0 == ws_set_init(set));
-    ck_assert(true == ws_object_deinit((struct ws_object*) set));
+    ws_object_deinit((struct ws_object*) set);
     ck_assert(0 == ws_set_init(set));
     // reinitialize here, so we do not segfault in the teardown function
 }


### PR DESCRIPTION
This PR redefines `ws_object_deinit` to invoke all deinitialization callbacks for a type.
Targets #372.

Note: I didn't go through all the deinitialization callbacks yet.
