### PR TITLE
Add event deserialization

### DIFF
--- a/src/objects/message/event.c
+++ b/src/objects/message/event.c
@@ -79,18 +79,22 @@ ws_event_init(
     }
 
     ret = ws_string_init(&self->name);
-    if (unlikely(ret != 0)) {
+    if (unlikely(ret == 0)) {
         goto deinit_obj;
     }
 
-    if (!ws_string_set_from_str(&self->name, name)) {
+    if (name && !ws_string_set_from_str(&self->name, name)) {
         goto deinit_obj;
     }
 
-    ret = ws_value_union_init_from_val(&self->context, ctx);
-    if (unlikely(ret != 0)) {
-        goto deinit_str;
+    if (ctx) {
+        ret = ws_value_union_init_from_val(&self->context, ctx);
+        if (unlikely(ret != 0)) {
+            goto deinit_str;
+        }
     }
+
+    self->m.obj.id = &WS_OBJECT_TYPE_ID_EVENT;
 
     return 0;
 

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -306,6 +306,25 @@ yajl_string_cb(
         }
         break;
 
+    case STATE_EVENT_NAME:
+        // This is the name of the event we are deserializing
+        {
+            state->ev_name = ws_string_new();
+            if (!state->ev_name) {
+                //!< @todo error, what now?
+                return 0;
+            }
+
+            char buff[len + 1];
+            memset(buff, 0, len + 1);
+            strncpy(buff, (char*) str, len);
+            ws_string_set_from_raw(state->ev_name, buff);
+            // ready for now.
+
+            state->current_state = STATE_MSG;
+        }
+        break;
+
     default:
         state->current_state = STATE_INVALID;
         break;

--- a/src/serialize/json/deserializer_state.c
+++ b/src/serialize/json/deserializer_state.c
@@ -65,6 +65,10 @@ deserialize_state_new(
     // Explicit set to EXEC here.
     state->flags            = WS_TRANSACTION_FLAGS_EXEC;
 
+    state->ev_ctx           = NULL;
+    state->ev_name          = NULL;
+    state->has_event        = false;
+
     return state;
 }
 

--- a/src/serialize/json/deserializer_state.h
+++ b/src/serialize/json/deserializer_state.h
@@ -59,6 +59,7 @@
 
 #include "objects/message/transaction.h"
 
+#include "values/union.h"
 #include "values/string.h"
 
 /**
@@ -80,6 +81,11 @@ struct deserializer_state {
 
     uintmax_t nboxbrackets;
     uintmax_t ncurvedbrackets;
+
+    struct ws_string* ev_name; //!< @public name cache for event name
+    struct ws_value* ev_ctx; //!< @public event context
+
+    bool has_event;
 };
 
 /**

--- a/src/serialize/json/keys.h
+++ b/src/serialize/json/keys.h
@@ -64,8 +64,12 @@
 #define FLAG_REGISTER "REGISTER"
 
 #define TYPE_TRANSACTION "transaction"
+#define TYPE_EVENT "event"
 
 #define POS         "pos" // key for argument: stack position
+
+#define EVENT_NAME  "name" // key for event name
+#define EVENT_VALUE "value" // key for event value
 
 #endif //__WS_SERIALIZE_JSON_KEYS_H__
 

--- a/src/serialize/json/states.h
+++ b/src/serialize/json/states.h
@@ -76,6 +76,10 @@ enum json_backend_state {
     STATE_COMMAND_ARY_COMMAND_ARG_INDIRECT, //!< We parsed a indirect value
     STATE_COMMAND_ARY_COMMAND_ARG_INDIRECT_STACKPOS, //!< stack position arg
 
+    STATE_EVENT_VALUE,
+    STATE_EVENT_VALUE_OBJ,
+    STATE_EVENT_NAME,
+
     STATE_STRING,
 };
 

--- a/src/serialize/json/string_jump_state.c
+++ b/src/serialize/json/string_jump_state.c
@@ -54,6 +54,16 @@ static const struct {
         .next = STATE_FLAGS_REGISTER,
         .str = FLAG_REGISTER
     },
+    {
+        .current = STATE_MSG,
+        .next = STATE_EVENT_NAME,
+        .str = EVENT_NAME
+    },
+    {
+        .current = STATE_MSG,
+        .next = STATE_EVENT_VALUE,
+        .str = EVENT_VALUE,
+    },
 
     { .str = NULL },
 };

--- a/tests/check/serialize/json_deserializer/test.c
+++ b/tests/check/serialize/json_deserializer/test.c
@@ -49,6 +49,7 @@
 #include "serialize/deserializer.h"
 #include "serialize/json/deserializer.h"
 #include "serialize/json/keys.h"
+#include "objects/message/event.h"
 #include "objects/message/message.h"
 #include "objects/message/transaction.h"
 #include "command/statement.h"
@@ -354,6 +355,18 @@ START_TEST (test_json_deserializer_flags) {
 }
 END_TEST
 
+START_TEST (test_json_deserializer_events) {
+    char const* buf = "{ \"" EVENT_NAME "\": \"testname\" }";
+
+    ssize_t s = ws_deserialize(d, &messagebuf, buf, strlen(buf));
+
+    ck_assert((unsigned long) s == strlen(buf));
+    ck_assert(messagebuf != NULL);
+
+    ck_assert(messagebuf->obj.id == &WS_OBJECT_TYPE_ID_EVENT);
+}
+END_TEST
+
 /*
  *
  * main()
@@ -385,6 +398,7 @@ json_deserializer_suite(void)
     tcase_add_test(tcx, test_json_deserializer_transaction_one_command);
     tcase_add_test(tcx, test_json_deserializer_transaction_commands);
     tcase_add_test(tcx, test_json_deserializer_flags);
+    tcase_add_test(tcx, test_json_deserializer_events);
 
     return s;
 }

--- a/tests/check/serialize/json_deserializer/test.c
+++ b/tests/check/serialize/json_deserializer/test.c
@@ -379,6 +379,38 @@ START_TEST (test_json_deserializer_events_with_type) {
 }
 END_TEST
 
+START_TEST (test_json_deserializer_events_with_everything) {
+    char const* buf =   "{"
+                        "\"" TYPE "\": \"" TYPE_EVENT "\","
+                        "\"" EVENT_NAME "\": \"testevent\","
+                        "\"" EVENT_VALUE "\": 1"
+                        "}";
+
+    ssize_t s = ws_deserialize(d, &messagebuf, buf, strlen(buf));
+
+    ck_assert((unsigned long) s == strlen(buf));
+    ck_assert(messagebuf != NULL);
+
+    ck_assert(messagebuf->obj.id == &WS_OBJECT_TYPE_ID_EVENT);
+
+    struct ws_event* e = (struct ws_event*) messagebuf;
+
+    { // compare names
+        struct ws_string* cmp = ws_string_new();
+        ck_assert(cmp);
+
+        ws_string_set_from_raw(cmp, "testevent");
+
+        ck_assert(0 == ws_string_cmp(&e->name, cmp));
+
+        ws_object_unref((struct ws_object*) cmp);
+    }
+
+    ck_assert(e->context.value.type == WS_VALUE_TYPE_INT);
+    ck_assert(e->context.int_.i == 1);
+}
+END_TEST
+
 /*
  *
  * main()
@@ -412,6 +444,7 @@ json_deserializer_suite(void)
     tcase_add_test(tcx, test_json_deserializer_flags);
     tcase_add_test(tcx, test_json_deserializer_events);
     tcase_add_test(tcx, test_json_deserializer_events_with_type);
+    tcase_add_test(tcx, test_json_deserializer_events_with_everything);
 
     return s;
 }

--- a/tests/check/serialize/json_deserializer/test.c
+++ b/tests/check/serialize/json_deserializer/test.c
@@ -367,6 +367,18 @@ START_TEST (test_json_deserializer_events) {
 }
 END_TEST
 
+START_TEST (test_json_deserializer_events_with_type) {
+    char const* buf = "{ \"" TYPE "\": \"" TYPE_EVENT "\" }";
+
+    ssize_t s = ws_deserialize(d, &messagebuf, buf, strlen(buf));
+
+    ck_assert((unsigned long) s == strlen(buf));
+    ck_assert(messagebuf != NULL);
+
+    ck_assert(messagebuf->obj.id == &WS_OBJECT_TYPE_ID_EVENT);
+}
+END_TEST
+
 /*
  *
  * main()
@@ -399,6 +411,7 @@ json_deserializer_suite(void)
     tcase_add_test(tcx, test_json_deserializer_transaction_commands);
     tcase_add_test(tcx, test_json_deserializer_flags);
     tcase_add_test(tcx, test_json_deserializer_events);
+    tcase_add_test(tcx, test_json_deserializer_events_with_type);
 
     return s;
 }


### PR DESCRIPTION
This PR targets #375 (event deserialization).

Steps to do:
- [x] Event finalization -> compiling an `ws_event` from cached values
- [x] Recognition of "event" type
- [x] Support for event names
- [x] Support for event values, including
  - [x] Direct: nil
  - [x] Direct: bool
  - [x] Direct: int
  - [x] Direct: string
- [x] Tests
