### PR TITLE
Fixup for keyboard event handling

### DIFF
--- a/src/input/input_device.c
+++ b/src/input/input_device.c
@@ -248,7 +248,7 @@ watch_pointers(
             }
             if (KEY_ESC <= ev.code && ev.code <= KEY_MICMUTE) {
                 handle_keyboard_press_event(&ev);
-                return;
+                continue;
             }
         }
 


### PR DESCRIPTION
We must use `continue` to process all events. This PR fixes this.
