### PR TITLE
Add ws_value_get_name()

### DIFF
--- a/src/values/value_type.c
+++ b/src/values/value_type.c
@@ -117,3 +117,10 @@ ws_value_type_instance_from_value_name(
     return v;
 }
 
+const char*
+ws_value_type_get_name(
+    struct ws_value* self
+) {
+    return WS_VALUE_TYPE_NAMES[ws_value_get_type(self)];
+}
+

--- a/src/values/value_type.h
+++ b/src/values/value_type.h
@@ -76,6 +76,18 @@ ws_value_type_instance_from_value_name(
     char const* name
 );
 
+/**
+ * Get the name of the type of the value object
+ *
+ * @memberof ws_value
+ *
+ * @return Name of the type of the passed value
+ */
+const char*
+ws_value_type_get_name(
+    struct ws_value* self //!< Value object to get the name for
+);
+
 #endif // __WS_VALUES_VALUE_TYPE_H__
 
 /**


### PR DESCRIPTION
This is a feature I would like to see merged for my work on #357.
It adds a function to get the name from a ws_value object.

Blocks #357
