### PR TITLE
Add ws_value_set_get() function

### DIFF
--- a/src/values/set.c
+++ b/src/values/set.c
@@ -72,6 +72,16 @@ ws_value_set_new(void) {
     return s;
 }
 
+struct ws_set*
+ws_value_set_get(
+    struct ws_value_set* self
+) {
+    if (self) {
+        return self->set;
+    }
+    return NULL;
+}
+
 int
 ws_value_set_insert(
     struct ws_value_set* self,

--- a/src/values/set.c
+++ b/src/values/set.c
@@ -89,7 +89,7 @@ ws_value_set_remove(
 }
 
 struct ws_object*
-ws_value_set_get(
+ws_value_set_get_object(
     struct ws_value_set const* self,
     struct ws_object const* cmp
 ) {

--- a/src/values/set.h
+++ b/src/values/set.h
@@ -121,7 +121,7 @@ __ws_nonnull__(1, 2)
  * @return the ws_object object or NULL on failure
  */
 struct ws_object*
-ws_value_set_get(
+ws_value_set_get_object(
     struct ws_value_set const* self, //!< The value_set object
     struct ws_object const* cmp //!< The object to compare to
 )

--- a/src/values/set.h
+++ b/src/values/set.h
@@ -83,6 +83,20 @@ struct ws_value_set*
 ws_value_set_new(void);
 
 /**
+ * Get the ws_set object stored in the value type
+ *
+ * @memberof ws_value_set
+ *
+ * @return The set stored in ws_value_set object, NULL on failure
+ */
+struct ws_set*
+ws_value_set_get(
+    struct ws_value_set* self
+)
+__ws_nonnull__(1)
+;
+
+/**
  * Insert an object into the set
  *
  * @memberof ws_value_set


### PR DESCRIPTION
Required for my work on #357.

The renaming of the old function was done, so the `ws_value_set_get()`
function name is consistent with the corresponding functions of the other
value types.

Blocks #357
