### PR TITLE
Add transaction testing framework

### DIFF
--- a/tests/check/serialize/CMakeLists.txt
+++ b/tests/check/serialize/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SUITES_SERIALIZER
     json_deserializer
     json_serializer
+    json_transaction
 )
 
 foreach(TEST IN LISTS TEST_SUITES_SERIALIZER)

--- a/tests/check/serialize/json_transaction/CMakeLists.txt
+++ b/tests/check/serialize/json_transaction/CMakeLists.txt
@@ -1,0 +1,55 @@
+find_package(EV REQUIRED)
+find_package(IcuIO REQUIRED)
+find_package(IcuUC REQUIRED)
+find_package(UUID REQUIRED)
+find_package(WaylandCursor REQUIRED)
+find_package(WaylandEgl REQUIRED)
+find_package(WaylandScanner REQUIRED)
+find_package(WaylandServer REQUIRED)
+find_package(Yajl REQUIRED)
+find_package(libreset REQUIRED)
+
+set(TEST_SOURCES
+    $<TARGET_OBJECTS:action>
+    $<TARGET_OBJECTS:command>
+    $<TARGET_OBJECTS:connection>
+    $<TARGET_OBJECTS:logger>
+    $<TARGET_OBJECTS:objects>
+    $<TARGET_OBJECTS:serialize>
+    $<TARGET_OBJECTS:util>
+    $<TARGET_OBJECTS:values>
+    PARENT_SCOPE)
+
+set(TEST_LIBRARIES
+    ${EV_LIBRARIES}
+    ${ICU_OP_LIBRARIES}
+    ${ICU_UC_LIBRARIES}
+    ${UUID_LIBRARIES}
+    ${WAYLAND_CURSOR_LIBRARIES}
+    ${WAYLAND_SERVER_LIBRARIES}
+    ${YAJL_LIBRARIES}
+    ${libreset_LIBRARIES}
+    PARENT_SCOPE)
+
+set(TEST_INCLUDE_DIRS
+    ${EV_INCLUDE_DIRS}
+    ${ICU_OP_INCLUDE_DIRS}
+    ${ICU_UC_INCLUDE_DIRS}
+    ${UUID_INCLUDE_DIRS}
+    ${WAYLAND_CURSOR_INCLUDE_DIRS}
+    ${WAYLAND_SERVER_INCLUDE_DIRS}
+    ${YAJL_INCLUDE_DIRS}
+    ${libreset_INCLUDE_DIRS}
+    PARENT_SCOPE)
+
+set(TEST_DEFINITIONS
+    ${EV_DEFINITIONS}
+    ${ICU_OP_DEFINITIONS}
+    ${ICU_UC_DEFINITIONS}
+    ${UUID_DEFINITIONS}
+    ${WAYLAND_CURSOR_DEFINITIONS}
+    ${WAYLAND_SERVER_DEFINITIONS}
+    ${YAJL_DEFINITIONS}
+    ${libreset_DEFINITIONS}
+    PARENT_SCOPE)
+

--- a/tests/check/serialize/json_transaction/test.c
+++ b/tests/check/serialize/json_transaction/test.c
@@ -67,6 +67,15 @@ static const struct {
 
         .out =  "{\"event\":{\"context\":1,\"name\":\"testevent\"}}"
     },
+    {
+        .in =   "{"
+                    "\"" TYPE "\": \"" TYPE_EVENT "\","
+                    "\"" EVENT_NAME "\": \"testevent\","
+                    "\"" EVENT_VALUE "\": \"testvalue\""
+                "}",
+
+        .out =  "{\"event\":{\"context\":\"testvalue\",\"name\":\"testevent\"}}"
+    },
 };
 
 /*

--- a/tests/check/serialize/json_transaction/test.c
+++ b/tests/check/serialize/json_transaction/test.c
@@ -1,0 +1,85 @@
+/*
+ * waysome - wayland based window manager
+ *
+ * Copyright in alphabetical order:
+ *
+ * Copyright (C) 2014-2015 Julian Ganz
+ * Copyright (C) 2014-2015 Manuel Messner
+ * Copyright (C) 2014-2015 Marcel Müller
+ * Copyright (C) 2014-2015 Matthias Beyer
+ * Copyright (C) 2014-2015 Nadja Sommerfeld
+ *
+ * This file is part of waysome.
+ *
+ * waysome is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * waysome is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with waysome. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @addtogroup tests "Testing"
+ *
+ * @{
+ */
+
+/**
+ * @addtogroup tests_objects "Testing: Serializer"
+ *
+ * @{
+ */
+
+/**
+ * @addtogroup tests_objects "Testing: Serializer: Transaction test"
+ *
+ * @{
+ */
+
+#include <check.h>
+#include "tests.h"
+
+#include "serialize/deserializer.h"
+#include "serialize/serializer.h"
+
+
+/*
+ *
+ * main()
+ *
+ */
+
+static Suite*
+json_serializer_transaction_suite(void)
+{
+    Suite* s    = suite_create("JSON (De)Serializer Suite");
+    TCase* tc   = tcase_create("main case");
+
+    suite_add_tcase(s, tc);
+
+    // tcase_add_test(tc, test_function);
+
+    return s;
+}
+
+WS_TESTS_CHECK_MAIN(json_serializer_transaction_suite);
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+

--- a/tests/check/serialize/json_transaction/test.c
+++ b/tests/check/serialize/json_transaction/test.c
@@ -76,6 +76,15 @@ static const struct {
 
         .out =  "{\"event\":{\"context\":\"testvalue\",\"name\":\"testevent\"}}"
     },
+    {
+        .in =   "{"
+                    "\"" TYPE "\": \"" TYPE_EVENT "\","
+                    "\"" EVENT_NAME "\": \"testevent\","
+                    "\"" EVENT_VALUE "\": null"
+                "}",
+
+        .out =  "{\"event\":{\"context\":null,\"name\":\"testevent\"}}"
+    },
 };
 
 /*

--- a/tests/check/serialize/json_transaction/test.c
+++ b/tests/check/serialize/json_transaction/test.c
@@ -85,6 +85,15 @@ static const struct {
 
         .out =  "{\"event\":{\"context\":null,\"name\":\"testevent\"}}"
     },
+    {
+        .in =   "{"
+                    "\"" TYPE "\": \"" TYPE_EVENT "\","
+                    "\"" EVENT_NAME "\": \"testevent\","
+                    "\"" EVENT_VALUE "\": true"
+                "}",
+
+        .out =  "{\"event\":{\"context\":true,\"name\":\"testevent\"}}"
+    },
 };
 
 /*


### PR DESCRIPTION
Please note: This is WIP.

Targets #339.

My approach: I have exactly one testing function which gets called in a loop,
check passes a `int` to it, which iteration is run atm. I use this `int`
as array index for the `inputs` array, which stores a input (which gets
deserialized) and an expeced output (which gets generated from the deserialized
message).

This can _only_ be done with "event" messages, as this is the only type
of message both the client and the "server" have to be able to talk.

---

Thoughts on this:
1. An event from the client to the server is not the same as an event from
   the server to the client. I guess we should redefine the API to look the same,
   shouldn't we? I consider this as important, but _NOT_ before the end of the
   project phase. We have more urgent things to do.
2. By now, this testing stuff has always buffers which are large enough.
   Other tests (with smaller buffers) can be added easily, but I consider this as
   secondary as well. An issue should be opened for this (with prio:low), right?
