### PR TITLE
[Refactor] Remove "run" callback

### DIFF
--- a/src/command/processor.c
+++ b/src/command/processor.c
@@ -119,7 +119,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_COMMAND_PROCESSOR = {
     .hash_callback = NULL,
     .deinit_callback = command_processor_deinit,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/compositor/buffer/buffer.c
+++ b/src/compositor/buffer/buffer.c
@@ -42,7 +42,6 @@ ws_buffer_type_id WS_OBJECT_TYPE_ID_BUFFER = {
 
         .deinit_callback = NULL,
         .dump_callback = NULL,
-        .run_callback = NULL,
         .cmp_callback = NULL,
 
         .attribute_table = NULL,

--- a/src/compositor/buffer/frame.c
+++ b/src/compositor/buffer/frame.c
@@ -69,7 +69,6 @@ ws_buffer_type_id WS_OBJECT_TYPE_ID_FRAME_BUFFER = {
 
         .deinit_callback = frame_buffer_deinit,
         .dump_callback = NULL,
-        .run_callback = NULL,
         .cmp_callback = NULL,
 
         .attribute_table = NULL,

--- a/src/compositor/buffer/image.c
+++ b/src/compositor/buffer/image.c
@@ -122,7 +122,6 @@ ws_buffer_type_id WS_OBJECT_TYPE_ID_IMAGE_BUFFER = {
 
         .deinit_callback = deinit_buffer,
         .dump_callback = NULL,
-        .run_callback = NULL,
         .cmp_callback = cmp_buffer,
 
         .attribute_table = NULL,

--- a/src/compositor/cursor.c
+++ b/src/compositor/cursor.c
@@ -62,7 +62,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_CURSOR = {
 
     .deinit_callback    = deinit_cursor,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
 

--- a/src/compositor/framebuffer_device.c
+++ b/src/compositor/framebuffer_device.c
@@ -73,7 +73,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_FRAMEBUFFER_DEVICE = {
     .deinit_callback = device_deinit,
     .hash_callback = device_hash,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = device_cmp,
 
     .attribute_table = NULL,

--- a/src/compositor/keyboard.c
+++ b/src/compositor/keyboard.c
@@ -99,7 +99,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_KEYBOARD = {
 
     .deinit_callback    = deinit_keyboard,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
 };
 

--- a/src/compositor/monitor.c
+++ b/src/compositor/monitor.c
@@ -93,7 +93,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_MONITOR = {
     .deinit_callback = monitor_deinit,
     .hash_callback = monitor_hash,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = monitor_cmp,
 
     .attribute_table = NULL,

--- a/src/compositor/monitor_mode.c
+++ b/src/compositor/monitor_mode.c
@@ -58,7 +58,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_MONITOR_MODE = {
     .deinit_callback = NULL,
     .hash_callback = monitor_mode_hash,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = monitor_mode_cmp,
 
     .attribute_table = NULL,

--- a/src/compositor/wayland/buffer.c
+++ b/src/compositor/wayland/buffer.c
@@ -132,7 +132,6 @@ static ws_buffer_type_id buffer_type = {
 
         .deinit_callback = NULL,
         .dump_callback = NULL,
-        .run_callback = NULL,
         .cmp_callback = NULL,
 
         .attribute_table = NULL,
@@ -161,7 +160,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_BUFFER = {
     .hash_callback = NULL,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
 
     .attribute_table = NULL,

--- a/src/compositor/wayland/client.c
+++ b/src/compositor/wayland/client.c
@@ -76,7 +76,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_CLIENT = {
     .hash_callback = hash_callback,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = cmp_callback,
 
     .attribute_table = NULL,

--- a/src/compositor/wayland/keyboard.c
+++ b/src/compositor/wayland/keyboard.c
@@ -64,7 +64,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_KEYBOARD = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
 };
 

--- a/src/compositor/wayland/pointer.c
+++ b/src/compositor/wayland/pointer.c
@@ -121,7 +121,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_POINTER = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
 

--- a/src/compositor/wayland/region.c
+++ b/src/compositor/wayland/region.c
@@ -124,7 +124,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_REGION = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
 

--- a/src/compositor/wayland/shell_surface.c
+++ b/src/compositor/wayland/shell_surface.c
@@ -204,7 +204,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_SHELL_SURFACE = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
 

--- a/src/compositor/wayland/surface.c
+++ b/src/compositor/wayland/surface.c
@@ -225,7 +225,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_SURFACE = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
 

--- a/src/compositor/wayland/xdg_shell.c
+++ b/src/compositor/wayland/xdg_shell.c
@@ -113,7 +113,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_XDG_SHELL = {
     .hash_callback = NULL,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .attribute_table = NULL,
     .function_table = NULL,

--- a/src/input/hotkey_event.c
+++ b/src/input/hotkey_event.c
@@ -63,7 +63,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_HOTKEY_EVENT = {
     .deinit_callback = deinit_hotkey,
 
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,

--- a/src/input/input_device.c
+++ b/src/input/input_device.c
@@ -80,7 +80,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_INPUT_DEVICE = {
     .hash_callback = hash_callback,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = cmp_callback,
     .uuid_callback = NULL,
 

--- a/src/objects/message/error_reply.c
+++ b/src/objects/message/error_reply.c
@@ -65,7 +65,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_ERROR_REPLY = {
     .hash_callback = NULL,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/objects/message/event.c
+++ b/src/objects/message/event.c
@@ -56,7 +56,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_EVENT = {
     .hash_callback = NULL,
     .deinit_callback = deinit_event,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/objects/message/message.c
+++ b/src/objects/message/message.c
@@ -44,7 +44,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_MESSAGE = {
     .hash_callback = NULL,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/objects/message/reply.c
+++ b/src/objects/message/reply.c
@@ -34,7 +34,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_REPLY = {
     .hash_callback = NULL,
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -68,7 +68,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_TRANSACTION = {
 
     .deinit_callback = deinit_transaction,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = cmp_transactions,
     .uuid_callback = NULL,

--- a/src/objects/message/value_reply.c
+++ b/src/objects/message/value_reply.c
@@ -55,7 +55,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_VALUE_REPLY = {
     .hash_callback = NULL,
     .deinit_callback = value_reply_deinit,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
 

--- a/src/objects/named.c
+++ b/src/objects/named.c
@@ -53,7 +53,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_NAMED = {
 
     .deinit_callback = named_deinit,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -79,7 +79,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_OBJECT = {
 
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,
@@ -271,32 +270,6 @@ ws_object_dump_state(
     }
 
     return res;
-}
-
-bool
-ws_object_run(
-    struct ws_object* self
-) {
-    if (!self) {
-        return false;
-    }
-
-    ws_log(&log_ctx, LOG_DEBUG, "Running: %p (%s)", self, self->id->typestr);
-
-    ws_object_type_id* type = self->id;
-    while (!type->run_callback) {
-        if (type == &WS_OBJECT_TYPE_ID_OBJECT) {
-            return false;
-        }
-
-        type = type->supertype;
-    }
-
-    ws_object_lock_read(self);
-    bool b = type->run_callback(self);
-    ws_object_unlock(self);
-
-    return b;
 }
 
 size_t

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -91,11 +91,6 @@ typedef bool (*ws_object_dump_callback)(
 );
 
 /**
- * run callback
- */
-typedef bool (*ws_object_run_callback)(struct ws_object* const);
-
-/**
  * hash callback
  */
 typedef size_t (*ws_object_hash_callback)(struct ws_object* const);
@@ -176,7 +171,6 @@ struct ws_object_type {
 
     ws_object_deinit_callback deinit_callback; //!< Free callback for the type
     ws_object_dump_callback dump_callback; //!< Log callback for the type
-    ws_object_run_callback run_callback; //!< Run callback for the type
     ws_object_hash_callback hash_callback; //!< Hash callback for the type
     ws_object_cmp_callback cmp_callback; //!< Compare callback for the type
     ws_object_uuid_callback uuid_callback; //!< @protected UUID callback

--- a/src/objects/set.c
+++ b/src/objects/set.c
@@ -104,7 +104,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_SET = {
     .deinit_callback = deinit_set,
 
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = NULL,
     .uuid_callback = NULL,

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -61,7 +61,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_STRING = {
 
     .deinit_callback = deinit_callback,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = (int (*) (struct ws_object const*, struct ws_object const*))
                     ws_string_cmp,

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -75,7 +75,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_OBJ = {
 
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .cmp_callback = cmp_callback,
     .uuid_callback = uuid_callback,
 

--- a/tests/check/objects/ws_object/attribute_test.c
+++ b/tests/check/objects/ws_object/attribute_test.c
@@ -81,7 +81,6 @@ ws_object_type_id WS_OBJECT_TYPE_ID_TESTOBJ = {
 
     .deinit_callback    = NULL,
     .dump_callback      = NULL,
-    .run_callback       = NULL,
     .hash_callback      = NULL,
     .cmp_callback       = NULL,
     .attribute_table = WS_OBJECT_ATTRS_TEST_OBJ,

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -119,13 +119,6 @@ START_TEST (test_object_cb_dump_state) {
 }
 END_TEST
 
-START_TEST (test_object_cb_run) {
-    struct ws_object* o = ws_object_new(sizeof(*o));
-    ck_assert(false == ws_object_run(o));
-    ws_object_deinit(o);
-}
-END_TEST
-
 START_TEST (test_object_cb_hash) {
     struct ws_object* o = ws_object_new(sizeof(*o));
     ck_assert(0 == ws_object_hash(o));
@@ -215,7 +208,6 @@ objects_suite(void)
     tcase_add_test(tc, test_object_getref);
     tcase_add_test(tc, test_object_unref);
     tcase_add_test(tc, test_object_cb_dump_state);
-    tcase_add_test(tc, test_object_cb_run);
     tcase_add_test(tc, test_object_cb_hash);
     tcase_add_test(tc, test_object_lock_read);
     tcase_add_test(tc, test_object_lock_write);

--- a/tests/check/objects/ws_set/test.c
+++ b/tests/check/objects/ws_set/test.c
@@ -70,7 +70,6 @@ ws_object_type_id TEST_ID = {
 
     .deinit_callback = NULL,
     .dump_callback = NULL,
-    .run_callback = NULL,
     .hash_callback = NULL,
     .cmp_callback = compare_set_test_objs,
 };


### PR DESCRIPTION
This PR removes the "run" callback from the `ws_object` type and all
callback tables.

The intention behind the run callback was that we might have objects
which are runnable. Turns out we don't have objects which need to be run.

This rips the code out of the codebase. Please review and/or discuss.
