### PR TITLE
Someone missed to add the CMakeLists.txt entry for the control.c file.

### DIFF
--- a/src/command/CMakeLists.txt
+++ b/src/command/CMakeLists.txt
@@ -34,6 +34,7 @@ set(WS_COMMAND_FILES
 #
 set(SOURCE_FILES
     command.c
+    control.c
     list.c
     processor.c
     statement.c


### PR DESCRIPTION
This PR fixes the missing CMakeLists.txt entry for the commands/control.c
file.
