### PR TITLE
Silence pdflatex

### DIFF
--- a/doc/user/CMakeLists.txt
+++ b/doc/user/CMakeLists.txt
@@ -38,7 +38,7 @@ endif ()
 # Build the PDF version of the documentation
 #
 add_custom_command(OUTPUT waysome.pdf
-    COMMAND ${PDFLATEX_COMPILER} -halt-on-error waysome
+    COMMAND ${PDFLATEX_COMPILER} -halt-on-error waysome > /dev/null
     DEPENDS ${BUILD_TEX_FILES}
 )
 


### PR DESCRIPTION
`pdflatex` spams a lot of output onto stdout. We don't need that output since it also produces a transcript.
