### PR TITLE
Add width/height setter methods for ws_shell_surface

### DIFF
--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -76,6 +76,21 @@ cmd_func_set_height(
     union ws_value_union* stack // The stack to use
 );
 
+/**
+ * Callback command function for setting surface width and height
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * Takes two parameters:
+ *  1) The object id of the surface
+ *  2) The width to set
+ *  2) The height to set
+ */
+static int
+cmd_func_set_width_and_height(
+    union ws_value_union* stack // The stack to use
+);
+
 /*
  *
  * Interface implementation
@@ -85,6 +100,7 @@ cmd_func_set_height(
 static const struct ws_object_function FUNCTIONS[] = {
     { .name = "setwidth",           .func = cmd_func_set_width },
     { .name = "setheight",          .func = cmd_func_set_height },
+    { .name = "setwidthheight",     .func = cmd_func_set_width_and_height },
     { .name = NULL,                 .func = NULL } // Iteration stopper
 };
 
@@ -263,5 +279,42 @@ cmd_func_set_height(
     }
 
     return ws_abstract_shell_surface_set_height(self, (int32_t) height);
+}
+
+static int
+cmd_func_set_width_and_height(
+    union ws_value_union* stack // The stack to use
+) {
+    if (ws_value_get_type(&stack[0].value) != WS_VALUE_TYPE_OBJECT_ID) {
+        return -EINVAL;
+    }
+
+    struct ws_abstract_shell_surface* shs;
+    shs = (struct ws_abstract_shell_surface*)
+            ws_value_object_id_get(&stack[0].object_id);
+
+    // `1` is the command string itself
+
+    if (ws_value_get_type(&stack[2].value) != WS_VALUE_TYPE_INT ||
+            ws_value_get_type(&stack[3].value) != WS_VALUE_TYPE_INT) {
+        ws_object_unref((struct ws_object*) shs);
+        return -EINVAL;
+    }
+
+    if (ws_value_get_type(&stack[4].value) != WS_VALUE_TYPE_NONE) {
+        ws_object_unref((struct ws_object*) shs);
+        return -E2BIG;
+    }
+
+    intmax_t width = ws_value_int_get(&stack[2].int_);
+    intmax_t height = ws_value_int_get(&stack[3].int_);
+    if (width > INT32_MAX || height > INT32_MAX) {
+        ws_object_unref((struct ws_object*) shs);
+        return -EINVAL;
+    }
+
+    return ws_abstract_shell_surface_set_width_and_height(shs,
+                                                          (int32_t) width,
+                                                          (int32_t) height);
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -111,6 +111,15 @@ ws_abstract_shell_surface_set_width(
     return 0;
 }
 
+int
+ws_abstract_shell_surface_set_height(
+    struct ws_abstract_shell_surface* self,
+    int32_t height
+) {
+    //!< @todo implement
+    return 0;
+}
+
 /*
  *
  * Internal implementation

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -62,6 +62,20 @@ cmd_func_set_width(
     union ws_value_union* stack // The stack to use
 );
 
+/**
+ * Callback command function for setting surface height
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * Takes two parameters:
+ *  1) The object id of the surface
+ *  2) The height to set
+ */
+static int
+cmd_func_set_height(
+    union ws_value_union* stack // The stack to use
+);
+
 /*
  *
  * Interface implementation
@@ -70,6 +84,7 @@ cmd_func_set_width(
 
 static const struct ws_object_function FUNCTIONS[] = {
     { .name = "setwidth",           .func = cmd_func_set_width },
+    { .name = "setheight",          .func = cmd_func_set_height },
     { .name = NULL,                 .func = NULL } // Iteration stopper
 };
 
@@ -215,5 +230,38 @@ cmd_func_set_width(
     }
 
     return ws_abstract_shell_surface_set_height(self, (int32_t) width);
+}
+
+static int
+cmd_func_set_height(
+    union ws_value_union* stack // The stack to use
+) {
+    if (ws_value_get_type(&stack[0].value) != WS_VALUE_TYPE_OBJECT_ID) {
+        return -EINVAL;
+    }
+
+    struct ws_abstract_shell_surface* self;
+    self = (struct ws_abstract_shell_surface*)
+            ws_value_object_id_get(&stack[0].object_id);
+
+    // `1` is the command string itself
+
+    if (ws_value_get_type(&stack[2].value) != WS_VALUE_TYPE_INT) {
+        ws_object_unref((struct ws_object*) self);
+        return -EINVAL;
+    }
+
+    if (ws_value_get_type(&stack[3].value) != WS_VALUE_TYPE_NONE) {
+        ws_object_unref((struct ws_object*) self);
+        return -E2BIG;
+    }
+
+    intmax_t height = ws_value_int_get(&stack[2].int_);
+    if (height > INT32_MAX) {
+        ws_object_unref((struct ws_object*) self);
+        return -EINVAL;
+    }
+
+    return ws_abstract_shell_surface_set_height(self, (int32_t) height);
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -170,7 +170,20 @@ ws_abstract_shell_surface_set_height(
     struct ws_abstract_shell_surface* self,
     int32_t height
 ) {
-    //!< @todo implement
+    static const uint32_t edges = 0; //!< @todo hardcoded?
+    struct ws_surface* s = (struct ws_surface*) self->surface;
+    if (!s) {
+        return -EINVAL;
+    }
+
+    s->height = height;
+
+    struct wl_resource* r = ws_wayland_obj_get_wl_resource(&s->wl_obj);
+    if (!r) {
+        return -EINVAL;
+    }
+
+    wl_shell_surface_send_configure(r, edges, s->width, height);
     return 0;
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -161,7 +161,20 @@ ws_abstract_shell_surface_set_width(
     struct ws_abstract_shell_surface* self,
     int32_t width
 ) {
-    //!< @todo implement
+    static const uint32_t edges = 0; //!< @todo hardcoded?
+    struct ws_surface* s = (struct ws_surface*) self->surface;
+    if (!s) {
+        return -EINVAL;
+    }
+
+    s->width = width;
+
+    struct wl_resource* r = ws_wayland_obj_get_wl_resource(&s->wl_obj);
+    if (!r) {
+        return -EINVAL;
+    }
+
+    wl_shell_surface_send_configure(r, edges, width, s->height);
     return 0;
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -120,6 +120,16 @@ ws_abstract_shell_surface_set_height(
     return 0;
 }
 
+int
+ws_abstract_shell_surface_set_width_and_height(
+    struct ws_abstract_shell_surface* self,
+    int32_t width,
+    int32_t height
+) {
+    //!< @todo implement
+    return 0;
+}
+
 /*
  *
  * Internal implementation

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -25,6 +25,8 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <wayland-server-protocol.h>
+
 #include "compositor/wayland/abstract_shell_surface.h"
 #include "compositor/wayland/surface.h"
 
@@ -126,7 +128,21 @@ ws_abstract_shell_surface_set_width_and_height(
     int32_t width,
     int32_t height
 ) {
-    //!< @todo implement
+    static const uint32_t edges = 0; //!< @todo hardcoded?
+    struct ws_surface* s = (struct ws_surface*) self->surface;
+    if (!s) {
+        return -EINVAL;
+    }
+
+    s->width = width;
+    s->height = height;
+
+    struct wl_resource* r = ws_wayland_obj_get_wl_resource(&s->wl_obj);
+    if (!r) {
+        return -EINVAL;
+    }
+
+    wl_shell_surface_send_configure(r, edges, width, height);
     return 0;
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -102,6 +102,14 @@ ws_abstract_shell_surface_set_pos(
     return 0;
 }
 
+int
+ws_abstract_shell_surface_set_width(
+    struct ws_abstract_shell_surface* self,
+    int32_t width
+) {
+    //!< @todo implement
+    return 0;
+}
 
 /*
  *

--- a/src/compositor/wayland/abstract_shell_surface.c
+++ b/src/compositor/wayland/abstract_shell_surface.c
@@ -25,10 +25,13 @@
  * along with waysome. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
+#include <wayland-server.h>
 #include <wayland-server-protocol.h>
 
 #include "compositor/wayland/abstract_shell_surface.h"
 #include "compositor/wayland/surface.h"
+#include "values/union.h"
 
 
 /*
@@ -45,12 +48,30 @@ shell_surface_deinit(
     struct ws_object* obj
 );
 
+/**
+ * Callback command function for setting surface width
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * Takes two parameters:
+ *  1) The object id of the surface
+ *  2) The width to set
+ */
+static int
+cmd_func_set_width(
+    union ws_value_union* stack // The stack to use
+);
 
 /*
  *
  * Interface implementation
  *
  */
+
+static const struct ws_object_function FUNCTIONS[] = {
+    { .name = "setwidth",           .func = cmd_func_set_width },
+    { .name = NULL,                 .func = NULL } // Iteration stopper
+};
 
 ws_object_type_id WS_OBJECT_TYPE_ID_ABSTRACT_SHELL_SURFACE = {
     .supertype  = &WS_OBJECT_TYPE_ID_WAYLAND_OBJ,
@@ -161,5 +182,38 @@ shell_surface_deinit(
 
     ws_object_unref((struct ws_object*) &shell_surf->surface);
     return true;
+}
+
+static int
+cmd_func_set_width(
+    union ws_value_union* stack // The stack to use
+) {
+    if (ws_value_get_type(&stack[0].value) != WS_VALUE_TYPE_OBJECT_ID) {
+        return -EINVAL;
+    }
+
+    struct ws_abstract_shell_surface* self;
+    self = (struct ws_abstract_shell_surface*)
+            ws_value_object_id_get(&stack[0].object_id);
+
+    // `1` is the command string itself
+
+    if (ws_value_get_type(&stack[2].value) != WS_VALUE_TYPE_INT) {
+        ws_object_unref((struct ws_object*) self);
+        return -EINVAL;
+    }
+
+    if (ws_value_get_type(&stack[3].value) != WS_VALUE_TYPE_NONE) {
+        ws_object_unref((struct ws_object*) self);
+        return -E2BIG;
+    }
+
+    intmax_t width = ws_value_int_get(&stack[2].int_);
+    if (width > INT32_MAX) {
+        ws_object_unref((struct ws_object*) self);
+        return -EINVAL;
+    }
+
+    return ws_abstract_shell_surface_set_height(self, (int32_t) width);
 }
 

--- a/src/compositor/wayland/abstract_shell_surface.h
+++ b/src/compositor/wayland/abstract_shell_surface.h
@@ -105,4 +105,18 @@ ws_abstract_shell_surface_set_height(
     int32_t height //!< The new height
 );
 
+/**
+ * Set the width and height of a ws_abstract_shell_surface
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * @return zero on success, else negative errno.h number
+ */
+int
+ws_abstract_shell_surface_set_width_and_height(
+    struct ws_abstract_shell_surface* self,
+    int32_t width, //!< The new width
+    int32_t height //!< The new height
+);
+
 #endif // __WAYSOME_ABSTRACT_SHELL_SURFACE_H__

--- a/src/compositor/wayland/abstract_shell_surface.h
+++ b/src/compositor/wayland/abstract_shell_surface.h
@@ -79,5 +79,17 @@ ws_abstract_shell_surface_set_pos(
 __ws_nonnull__(1)
 ;
 
+/**
+ * Set the width of a ws_abstract_shell_surface
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * @return zero on success, else negative errno.h number
+ */
+int
+ws_abstract_shell_surface_set_width(
+    struct ws_abstract_shell_surface* self,
+    int32_t width //!< The new width
+);
 
 #endif // __WAYSOME_ABSTRACT_SHELL_SURFACE_H__

--- a/src/compositor/wayland/abstract_shell_surface.h
+++ b/src/compositor/wayland/abstract_shell_surface.h
@@ -92,4 +92,17 @@ ws_abstract_shell_surface_set_width(
     int32_t width //!< The new width
 );
 
+/**
+ * Set the height of a ws_abstract_shell_surface
+ *
+ * @memberof ws_abstract_shell_surface
+ *
+ * @return zero on success, else negative errno.h number
+ */
+int
+ws_abstract_shell_surface_set_height(
+    struct ws_abstract_shell_surface* self,
+    int32_t height //!< The new height
+);
+
 #endif // __WAYSOME_ABSTRACT_SHELL_SURFACE_H__

--- a/src/compositor/wayland/surface.h
+++ b/src/compositor/wayland/surface.h
@@ -51,6 +51,8 @@ struct ws_surface {
     struct wl_interface const* role; //!< @protected role of this surface
     int32_t x; //!< @public x position of this surface
     int32_t y; //!< @public y position of this surface
+    int32_t width; //!< @public width of the surface
+    int32_t height; //!< @public height of the surface
 };
 
 /**


### PR DESCRIPTION
Targets #457.

I'm not sure about the convenience method, which allows setting of the
width and height in one step, but I think it is basically a good idea.
