### PR TITLE
Rework object locking

### DIFF
--- a/src/action/manager.h
+++ b/src/action/manager.h
@@ -52,6 +52,9 @@ ws_action_manager_init(
 /**
  * Process a transaction
  *
+ * @note Should be called with reference on the transaction message already
+ * aquired.
+ *
  * @return the reply caused by the transaction being processed
  */
 struct ws_reply*
@@ -82,6 +85,8 @@ __ws_nonnull__(1, 2)
  *
  * @note undos what `ws_action_manager_register()` does
  *
+ * @note Should be called with already aquired ref on argument.
+ *
  * @return 0 on success, a negative error number otherwise
  */
 int
@@ -96,6 +101,8 @@ __ws_nonnull__(1)
  *
  * @note after removal, the transaction cannot be registered to be run on
  *       events any more, existing registrations are, however, not removed
+ *
+ * @note Should be called with already aquired ref on argument.
  *
  * @return 0 on success, a negative error number otherwise
  */

--- a/src/action/manager.h
+++ b/src/action/manager.h
@@ -39,6 +39,9 @@ struct ws_string;
 /**
  * Initialize the action manager
  *
+ * @note Tries to get reference on the context object, returns -EBUSY if
+ * reference could not be aquired.
+ *
  * @return 0 on success, a negative error number otherwise
  */
 int

--- a/src/compositor/buffer/buffer.h
+++ b/src/compositor/buffer/buffer.h
@@ -98,6 +98,8 @@ ws_buffer_init(
  *
  * @warning to not pass NULL to this function! It will crash!
  *
+ * @note Should be called with ref on argument already aquired!
+ *
  * @memberof ws_buffer
  *
  * @return pointer to the buffer's contents
@@ -113,6 +115,8 @@ __ws_nonnull__(1)
  * Get the buffer's width
  *
  * @warning to not pass NULL to this function! It will crash!
+ *
+ * @note Should be called with ref on argument already aquired!
  *
  * @memberof ws_buffer
  *
@@ -130,6 +134,8 @@ __ws_nonnull__(1)
  *
  * @warning to not pass NULL to this function! It will crash!
  *
+ * @note Should be called with ref on argument already aquired!
+ *
  * @memberof ws_buffer
  *
  * @return height of the buffer's contents
@@ -145,6 +151,8 @@ __ws_nonnull__(1)
  * Get the buffer's stride
  *
  * @warning to not pass NULL to this function! It will crash!
+ *
+ * @note Should be called with ref on argument already aquired!
  *
  * @memberof ws_buffer
  *
@@ -162,6 +170,8 @@ __ws_nonnull__(1)
  *
  * @warning to not pass NULL to this function! It will crash!
  *
+ * @note Should be called with ref on argument already aquired!
+ *
  * @memberof ws_buffer
  *
  * @return format of the buffer's contents
@@ -175,6 +185,8 @@ __ws_nonnull__(1)
 
 /**
  * Get the buffer's bits per pixel
+ *
+ * @note Should be called with ref on argument already aquired!
  *
  * @memberof ws_buffer
  *
@@ -190,6 +202,8 @@ __ws_nonnull__(1)
 /**
  * Begin buffer access
  *
+ * @note Should be called with ref on argument already aquired!
+ *
  * @memberof ws_buffer
  *
  * @warning to not pass NULL to this function! It will crash!
@@ -203,6 +217,8 @@ __ws_nonnull__(1)
 /**
  * End buffer access
  *
+ * @note Should be called with ref on argument already aquired!
+ *
  * @memberof ws_buffer
  *
  * @warning to not pass NULL to this function! It will crash!
@@ -215,6 +231,8 @@ __ws_nonnull__(1)
 ;
 /**
  * Blit two buffers together (This copies one into the other)
+ *
+ * @note Should be called with ref on argument already aquired!
  *
  * @memberof ws_buffer
  *

--- a/src/compositor/buffer/buffer.h
+++ b/src/compositor/buffer/buffer.h
@@ -84,6 +84,8 @@ extern ws_buffer_type_id WS_OBJECT_TYPE_ID_BUFFER;
  *
  * @memberof ws_buffer
  *
+ * @note Gets ref on the object via ws_object_init()
+ *
  * @return zero on success, else negative errno.h constant
  */
 int

--- a/src/compositor/buffer/egl.h
+++ b/src/compositor/buffer/egl.h
@@ -81,6 +81,8 @@ __ws_nonnull__(1)
  *
  * @memberof ws_egl_buffer
  *
+ * @note Gets ref on object via ws_buffer_init()
+ *
  * @return a newly created EGL buffer
  */
 struct ws_egl_buffer*

--- a/src/compositor/buffer/frame.h
+++ b/src/compositor/buffer/frame.h
@@ -74,6 +74,8 @@ extern ws_buffer_type_id WS_OBJECT_TYPE_ID_FRAME_BUFFER;
  *
  * @memberof ws_frame_buffer
  *
+ * @note Gets ref on the object via ws_buffer_init()
+ *
  * @return the device on success, NULL on failure
  */
 struct ws_frame_buffer*

--- a/src/connection/processor.c
+++ b/src/connection/processor.c
@@ -226,7 +226,7 @@ connection_manager_dispatch(
     proc = (struct ws_connection_manager*) watcher->data;
     ssize_t res;
 
-    if (!ws_object_lock_try_write(&proc->obj)) {
+    if (ws_object_lock_try_write(&proc->obj) != 0) {
         return;
     }
 
@@ -319,7 +319,7 @@ connection_manager_flush(
     proc = (struct ws_connection_manager*) watcher->data;
 
     // try to lock the object
-    if (!ws_object_lock_try_write(&proc->obj)) {
+    if (ws_object_lock_try_write(&proc->obj) != 0) {
         goto unlock;
     }
 

--- a/src/objects/message/error_reply.c
+++ b/src/objects/message/error_reply.c
@@ -125,6 +125,8 @@ char const*
 ws_error_reply_get_description(
     struct ws_error_reply* self //!< error reply from which to extract the code
 ) {
+    // No locking here, as the description is constant (not `const` as
+    // `ws_error_reply_new()` sets it
     if (self->description) {
         return self->description;
     }

--- a/src/objects/message/error_reply.c
+++ b/src/objects/message/error_reply.c
@@ -116,6 +116,8 @@ unsigned int
 ws_error_reply_get_code(
     struct ws_error_reply* self //!< error reply from which to extract the code
 ) {
+    // No locking here, as the code is constant (not `const` as
+    // `ws_error_reply_new()` sets it
     return self->code;
 }
 

--- a/src/objects/message/error_reply.c
+++ b/src/objects/message/error_reply.c
@@ -137,6 +137,8 @@ char const*
 ws_error_reply_get_cause(
     struct ws_error_reply* self //!< error reply from which to extract the code
 ) {
+    // No locking here, as the cause is constant (not `const` as
+    // `ws_error_reply_new()` sets it
     if (self->cause) {
         return self->cause;
     }

--- a/src/objects/message/event.c
+++ b/src/objects/message/event.c
@@ -135,7 +135,7 @@ struct ws_string*
 ws_event_get_name(
     struct ws_event* self
 ) {
-    return &self->name;
+    return getref(&self->name);
 }
 
 union ws_value_union*

--- a/src/objects/message/event.h
+++ b/src/objects/message/event.h
@@ -84,6 +84,8 @@ __ws_nonnull__(1)
  *
  * @memberof ws_event
  *
+ * Gets a reference on the name object.
+ *
  * @return The name of the event or NULL on failure
  */
 struct ws_string*

--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -49,6 +49,8 @@ deinit_transaction(
 
 /**
  * Compare two transactions
+ *
+ * @note Guaranteed to be read-locked when called from ws_object_cmp().
  */
 static int
 cmp_transactions(

--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -233,12 +233,13 @@ static bool
 deinit_transaction(
     struct ws_object* self
 ) {
+    ws_object_lock_write(self);
     struct ws_transaction* t = (struct ws_transaction*) self;
 
     ws_object_unref((struct ws_object*) t->name);
 
     if (!t->cmds) {
-        return true;
+        goto out;
     }
 
     if (!t->cmds->statements) {
@@ -252,6 +253,7 @@ deinit_transaction(
 
 out:
     t->cmds->num = 0;
+    ws_object_unlock(self);
     return true;
 }
 

--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -186,6 +186,8 @@ ws_transaction_push_statement(
     struct ws_transaction* t,
     struct ws_statement* statement
 ) {
+    ws_object_lock_write(&t->m.obj);
+
     if (!t->cmds) {
         t->cmds = calloc(1, sizeof(*t->cmds));
         if (!t->cmds) {
@@ -204,6 +206,7 @@ ws_transaction_push_statement(
         tmp = realloc(t->cmds->statements, newsize);
 
         if (!tmp) {
+            ws_object_unlock(&t->m.obj);
             return -ENOMEM;
         }
 
@@ -216,6 +219,7 @@ ws_transaction_push_statement(
     t->cmds->statements[t->cmds->num].args.vals = statement->args.vals;
     t->cmds->num++;
 
+    ws_object_unlock(&t->m.obj);
     return 0;
 }
 

--- a/src/objects/message/value_reply.c
+++ b/src/objects/message/value_reply.c
@@ -106,6 +106,7 @@ struct ws_value*
 ws_value_reply_get_value(
     struct ws_value_reply* self
 ) {
+    // No locking here as the value of the value reply shouldn't change
     return &self->value.value;
 }
 

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -299,11 +299,11 @@ ws_object_lock_try_read(
     return -pthread_rwlock_tryrdlock(&self->rw_lock);
 }
 
-bool
+int
 ws_object_lock_try_write(
     struct ws_object* self
 ) {
-    return 0 == pthread_rwlock_trywrlock(&self->rw_lock);
+    return -pthread_rwlock_trywrlock(&self->rw_lock);
 }
 
 bool

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -292,11 +292,11 @@ ws_object_lock_write(
     return 0 == pthread_rwlock_wrlock(&self->rw_lock);
 }
 
-bool
+int
 ws_object_lock_try_read(
     struct ws_object* self
 ) {
-    return 0 == pthread_rwlock_tryrdlock(&self->rw_lock);
+    return -pthread_rwlock_tryrdlock(&self->rw_lock);
 }
 
 bool

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -251,12 +251,12 @@ ws_object_unref(
     free(self);
 }
 
-size_t
+ssize_t
 ws_object_hash(
     struct ws_object* self
 ) {
     if (!self) {
-        return false;
+        return -EINVAL;
     }
 
     ws_log(&log_ctx, LOG_DEBUG, "Hashing: %p (%s)", self, self->id->typestr);
@@ -265,7 +265,7 @@ ws_object_hash(
     while (!type->hash_callback) {
         // we hit the basic object type, which is totally abstract
         if (type == &WS_OBJECT_TYPE_ID_OBJECT) {
-            return false;
+            return -ENOTSUP;
         }
 
         type = type->supertype;

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -335,9 +335,9 @@ ws_object_run(
  *
  * @memberof ws_object
  *
- * @return the object hash as a `size_t`
+ * @return the object hash as a `size_t` or negative errno.h number
  */
-size_t
+ssize_t
 ws_object_hash(
     struct ws_object* self //!< The object
 );

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -371,9 +371,9 @@ ws_object_lock_write(
  *
  * @memberof ws_object
  *
- * @return true if the lock was aquired, false otherwise
+ * @return zero on success, else a negative errno.h number (from pthread call)
  */
-bool
+int
 ws_object_lock_try_read(
     struct ws_object* self //!< The object to lock
 );

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -505,6 +505,8 @@ __ws_nonnull__(1, 2)
  *
  * @warning If the type has no compare callback, the return value is undefined.
  *
+ * @note Aquires read-locks on both objects.
+ *
  * @return -1 if `o1` is bigger, zero if they are equal, 1 if `o2` is bigger
  */
 int

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -383,9 +383,9 @@ ws_object_lock_try_read(
  *
  * @memberof ws_object
  *
- * @return true if the lock was aquired, false otherwise
+ * @return zero on success, else a negative errno.h number (from pthread call)
  */
-bool
+int
 ws_object_lock_try_write(
     struct ws_object* self //!< The object to lock
 );

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -50,6 +50,8 @@ hash_callback(
 
 /**
  * Compare callback for `ws_wayland_obj` type
+ *
+ * @note Guaranteed to be read-locked when called from ws_object_cmp().
  */
 int
 cmp_callback(

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -139,7 +139,9 @@ ws_wayland_obj_set_wl_resource(
     struct ws_wayland_obj* self,
     struct wl_resource* resource
 ) {
+    ws_object_lock_write(&self->obj);
     self->resource = resource;
+    ws_object_unlock(&self->obj);
 }
 
 /*

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -40,6 +40,8 @@
 
 /**
  * Hashing callback for `ws_wayland_obj` type
+ *
+ * @note Read-locked via call from ws_object_hash()
  */
 static size_t
 hash_callback(

--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -127,11 +127,14 @@ struct wl_resource*
 ws_wayland_obj_get_wl_resource(
     struct ws_wayland_obj* self
 ) {
+    struct wl_resource* res = NULL;
     if (self) {
-        return self->resource;
+        ws_object_lock_read(&self->obj);
+        res = self->resource;
+        ws_object_unlock(&self->obj);
     }
 
-    return NULL;
+    return res;
 }
 
 void

--- a/src/objects/wayland_obj.h
+++ b/src/objects/wayland_obj.h
@@ -102,6 +102,8 @@ ws_wayland_obj_get_wl_resource(
  * Set the wl_resource to encapsulate in the ws_wayland_obj object
  *
  * @memberof ws_wayland_obj
+ *
+ * @note Write-locks the object for modifying it.
  */
 void
 ws_wayland_obj_set_wl_resource(

--- a/src/objects/wayland_obj.h
+++ b/src/objects/wayland_obj.h
@@ -91,6 +91,8 @@ ws_wayland_obj_new(
  *
  * @memberof ws_wayland_obj
  *
+ * @note Read-locks the object for reading it.
+ *
  * @return the wl_resource instance from the object
  */
 struct wl_resource*

--- a/src/serialize/serializer.c
+++ b/src/serialize/serializer.c
@@ -62,8 +62,8 @@ ws_serialize(
     }
 
     // now try to serialize the message we have now
-    ws_object_lock_write(&msg->obj);
     self->buffer = getref(msg);
+    ws_object_lock_write(&msg->obj);
     ssize_t retval = self->serialize(self, buf, nbuf);
     ws_object_unlock(&msg->obj);
     if (retval < 0) {

--- a/src/serialize/serializer.c
+++ b/src/serialize/serializer.c
@@ -62,8 +62,10 @@ ws_serialize(
     }
 
     // now try to serialize the message we have now
+    ws_object_lock_write(&msg->obj);
     self->buffer = getref(msg);
     ssize_t retval = self->serialize(self, buf, nbuf);
+    ws_object_unlock(&msg->obj);
     if (retval < 0) {
         return retval;
     }

--- a/src/serialize/serializer.h
+++ b/src/serialize/serializer.h
@@ -77,6 +77,10 @@ struct ws_serializer {
  * return either the number of bytes written to that buffer or a negative error
  * code.
  *
+ * @warning This _fails_ when it is called from two threads on the same
+ * serializer. This should be called only once for one serializer. It will
+ * write-lock the message object, though.
+ *
  * @note in the case that the message could not be serialized because another
  *       message is still pending, `-EAGAIN` will be returned, indicating that
  *       the message may be serialized successfully later.

--- a/src/values/object_id.c
+++ b/src/values/object_id.c
@@ -78,13 +78,13 @@ ws_value_object_id_set(
         return;
     }
 
-    if (self->obj) {
-        ws_object_unref(self->obj);
-    }
-
     struct ws_object* tmp = getref(obj);
     if (!tmp) {
         return;
+    }
+
+    if (self->obj) {
+        ws_object_unref(self->obj);
     }
 
     self->obj = tmp;

--- a/src/values/string.c
+++ b/src/values/string.c
@@ -79,7 +79,7 @@ ws_value_string_get(
     struct ws_value_string* self
 ){
     if (self) {
-        return self->str;
+        return getref(self->str);
     }
 
     return NULL;

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -37,6 +37,7 @@
  * @{
  */
 
+#include <errno.h>
 #include <check.h>
 #include <stdbool.h>
 
@@ -114,7 +115,7 @@ END_TEST
 
 START_TEST (test_object_cb_hash) {
     struct ws_object* o = ws_object_new(sizeof(*o));
-    ck_assert(0 == ws_object_hash(o));
+    ck_assert(-ENOTSUP == ws_object_hash(o));
     ws_object_deinit(o);
 }
 END_TEST

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -138,7 +138,7 @@ END_TEST
 
 START_TEST (test_object_lock_try_read) {
     struct ws_object* o = ws_object_new(sizeof(*o));
-    ck_assert(true == ws_object_lock_try_read(o));
+    ck_assert(0 == ws_object_lock_try_read(o));
     ck_assert(true == ws_object_unlock(o));
     ws_object_deinit(o);
 }

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -146,7 +146,7 @@ END_TEST
 
 START_TEST (test_object_lock_try_write) {
     struct ws_object* o = ws_object_new(sizeof(*o));
-    ck_assert(true == ws_object_lock_try_write(o));
+    ck_assert(0 == ws_object_lock_try_write(o));
     ck_assert(true == ws_object_unlock(o));
     ws_object_deinit(o);
 }


### PR DESCRIPTION
This PR reworks the object locking.

It
- Adds note why locking is not required in some cases
- Adds locking where it is missing
- Adds ref counting where it is missing

This is **WIP**, the following modules are on my todo-list:
- [X] `src/objects/`
- [ ] `src/compositor/`
- [x] `src/action`
- [x] `src/serialize`
- [x] `src/values`

Feel free to propose more, participate in this PR (just notify me which stuff
you want to do) or the like!
