### PR TITLE
Add error identification in deserializer code

### DIFF
--- a/src/serialize/json/deserializer.c
+++ b/src/serialize/json/deserializer.c
@@ -190,6 +190,20 @@ deserialize(
 
     yajl_status stat = yajl_parse(d->handle, buffer, nbuf);
 
+    if (stat == yajl_status_client_canceled) {
+        // the parsing resulted in an error.
+        static char* y_err_fmt = "YAJL parser error (code %i)";
+        static char* d_err_fmt = "Deserializer error (code %i)";
+        char* fmt;
+        if (d->error.parser_error) {
+            fmt = y_err_fmt;
+        } else {
+            fmt = d_err_fmt;
+        }
+
+        ws_log(&log_ctx, LOG_ERR, fmt, d->error.error_num);
+    }
+
     if ((d->current_state == STATE_INVALID) && self->buffer) {
         ws_object_deinit(&self->buffer->obj);
         self->buffer = NULL;

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -136,14 +136,17 @@ yajl_null_cb(
         {
             struct ws_value_nil* nil = calloc(1, sizeof(*nil));
             if (!nil) {
-                //!< @todo error
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
             ws_value_nil_init(nil);
 
-            if (0 != ws_statement_append_direct(state->tmp_statement,
-                                                (struct ws_value*) nil)) {
-                //!< @todo error
+            int res = ws_statement_append_direct(state->tmp_statement,
+                                                (struct ws_value*) nil);
+            if (res != 0) {
+                state->error.parser_error = false;
+                state->error.error_num = res;
                 return 0;
             }
 
@@ -157,7 +160,8 @@ yajl_null_cb(
             state->has_event = true;
             struct ws_value_nil* nil = calloc(1, sizeof(*nil));
             if (!nil) {
-                //!< @tod error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
             ws_value_nil_init(nil);

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -388,9 +388,11 @@ yajl_string_cb(
                 return 0;
             }
 
-            if (0 != ws_statement_append_direct(state->tmp_statement,
-                                                (struct ws_value*) s)) {
-                //!< @todo error
+            res = ws_statement_append_direct(state->tmp_statement,
+                                             (struct ws_value*) s);
+            if (res != 0) {
+                state->error.parser_error = false;
+                state->error.error_num = res;
                 return 0;
             }
 
@@ -402,7 +404,8 @@ yajl_string_cb(
         {
             state->register_name = ws_string_new();
             if (!state->register_name) {
-                //!< @todo error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 
@@ -427,7 +430,8 @@ yajl_string_cb(
             state->has_event = true;
             state->ev_name = ws_string_new();
             if (!state->ev_name) {
-                //!< @todo error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 
@@ -453,7 +457,8 @@ yajl_string_cb(
             state->has_event = true;
             struct ws_value_string* s = ws_value_string_new();
             if (!s) {
-                //!< @tod error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -275,15 +275,18 @@ yajl_integer_cb(
         {
             struct ws_value_int* _i = calloc(1, sizeof(_i));
             if (!_i) {
-                //!< @todo error
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 
             ws_value_int_init(_i);
             ws_value_int_set(_i, i);
-            if (0 != ws_statement_append_direct(state->tmp_statement,
-                                                (struct ws_value*) _i)) {
-                //!< @todo error
+            int res = ws_statement_append_direct(state->tmp_statement,
+                                                 (struct ws_value*) _i);
+            if (res != 0) {
+                state->error.parser_error = false;
+                state->error.error_num = res;
                 return 0;
             }
 
@@ -311,7 +314,8 @@ yajl_integer_cb(
             state->has_event = true;
             struct ws_value_int* n = calloc(1, sizeof(*n));
             if (!n) {
-                //!< @tod error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
             ws_value_int_init(n);

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -555,12 +555,15 @@ yajl_map_key_cb(
 
             state->tmp_statement = calloc(1, sizeof(*state->tmp_statement));
             if (!state->tmp_statement) {
-                //!< @todo error?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 
-            if (0 != ws_statement_init(state->tmp_statement, buf)) {
-                //!< @todo error?
+            int res = ws_statement_init(state->tmp_statement, buf);
+            if (res != 0) {
+                state->error.parser_error = false;
+                state->error.error_num = res;
                 return 0;
             }
 

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -195,15 +195,18 @@ yajl_boolean_cb(
         {
             struct ws_value_bool* boo = calloc(1, sizeof(*boo));
             if (!boo) {
-                //!< @todo error
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
 
             ws_value_bool_init(boo);
             ws_value_bool_set(boo, b);
-            if (0 != ws_statement_append_direct(state->tmp_statement,
-                                                (struct ws_value*) boo)) {
-                //!< @todo error
+            int res = ws_statement_append_direct(state->tmp_statement,
+                                                (struct ws_value*) boo);
+            if (res != 0) {
+                state->error.parser_error = false;
+                state->error.error_num = res;
                 return 0;
             }
             state->current_state = STATE_COMMAND_ARY_COMMAND_ARGS;
@@ -225,7 +228,8 @@ yajl_boolean_cb(
             state->has_event = true;
             struct ws_value_bool* boo = calloc(1, sizeof(*boo));
             if (!b) {
-                //!< @tod error, what now?
+                state->error.parser_error = false;
+                state->error.error_num = -ENOMEM;
                 return 0;
             }
             ws_value_bool_init(boo);

--- a/src/serialize/json/deserializer_callbacks.h
+++ b/src/serialize/json/deserializer_callbacks.h
@@ -84,6 +84,11 @@ struct deserializer_state {
     struct ws_value* ev_ctx; //!< @public event context
 
     bool has_event;
+
+    struct {
+        bool parser_error;
+        int error_num;
+    } error;
 };
 
 /**


### PR DESCRIPTION
This PR introduces some simple error identification by setting
appropriate variables.

Targets #467 partly, as it removes **some** `@todo`s from
`src/serialize/json/deserializer_callbacks.c`.
