### PR TITLE
Cleanup ws_string type implementation

### DIFF
--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -154,28 +154,21 @@ ws_string_cat(
     ws_object_lock_write(&self->obj);
     ws_object_lock_read(&other->obj); //!< @todo Thread-safeness!
 
-    UChar* temp;
-    size_t charcount_s = u_strlen(self->str);
-    size_t charcount_o = u_strlen(other->str);
-    temp = realloc(self->str, (charcount_s + charcount_o + 1)
-                    * sizeof(*self->str));
+    size_t new_len = u_strlen(self->str) + u_strlen(other->str) + 1;
+    UChar* temp = realloc(self->str, new_len * sizeof(*self->str));
     if (!temp) {
         ws_object_unlock(&other->obj);
         ws_object_unlock(&self->obj);
         return NULL;
     }
-
     self->str = temp;
-    self->str = u_strcat(self->str, other->str);
+
+    u_strcat(self->str, other->str);
 
     ws_object_unlock(&other->obj);
     ws_object_unlock(&self->obj);
 
-    if (self->str) {
-        return self;
-    }
-
-    return NULL;
+    return self;
 }
 
 struct ws_string*

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -73,20 +73,19 @@ bool
 ws_string_init(
     struct ws_string* self
 ) {
-    if (self) {
-        self->str = calloc(1, sizeof(*self->str)); //initialize as empty string
-
-        if (!self->str) {
-            return false;
-        }
-
-        ws_object_init(&self->obj);
-        self->obj.id = &WS_OBJECT_TYPE_ID_STRING;
-
-        return true;
+    if (!self) {
+        return false;
     }
 
-    return false;
+    self->str = calloc(1, sizeof(*self->str)); //initialize as empty string
+    if (!self->str) {
+        return false;
+    }
+
+    ws_object_init(&self->obj);
+    self->obj.id = &WS_OBJECT_TYPE_ID_STRING;
+
+    return true;
 }
 
 bool

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -31,9 +31,9 @@
 #include <string.h>
 #include <unicode/ustring.h>
 
-#include "objects/string.h"
-
 #include "objects/object.h"
+#include "objects/string.h"
+#include "util/condition.h"
 
 /*
  *
@@ -79,7 +79,7 @@ ws_string_init(
     }
 
     self->str = calloc(1, sizeof(*self->str)); //initialize as empty string
-    if (!self->str) {
+    if (unlikely(!self->str)) {
         return false;
     }
 
@@ -94,7 +94,7 @@ ws_string_set_from_str(
     struct ws_string* self,
     struct ws_string* other
 ) {
-    if (!self || !other) {
+    if (unlikely(!self || !other)) {
         return false;
     }
 
@@ -104,7 +104,7 @@ ws_string_set_from_str(
     size_t charcount = u_strlen(other->str);
 
     UChar* temp = realloc(self->str, (charcount + 1) * sizeof(*self->str));
-    if (!temp) {
+    if (unlikely(!temp)) {
         ws_object_unlock(&other->obj);
         ws_object_unlock(&self->obj);
         return false;
@@ -124,7 +124,7 @@ ws_string_new(void)
 {
     struct ws_string* wss = calloc(1, sizeof(*wss));
 
-    if (wss) {
+    if (likely(wss)) {
         ws_string_init(wss);
         wss->obj.settings |= WS_OBJECT_HEAPALLOCED;
     }
@@ -136,7 +136,7 @@ size_t
 ws_string_len(
     struct ws_string* self
 ){
-    if (self) {
+    if (likely(self)) {
         size_t len;
         ws_object_lock_read(&self->obj);
         len = u_strlen(self->str);
@@ -157,7 +157,7 @@ ws_string_cat(
 
     size_t new_len = u_strlen(self->str) + u_strlen(other->str) + 1;
     UChar* temp = realloc(self->str, new_len * sizeof(*self->str));
-    if (!temp) {
+    if (unlikely(!temp)) {
         ws_object_unlock(&other->obj);
         ws_object_unlock(&self->obj);
         return NULL;
@@ -177,7 +177,7 @@ ws_string_dupl(
     struct ws_string* self
 ){
     struct ws_string* nstr = ws_string_new();
-    if (!nstr || !ws_string_set_from_str(nstr, self)) {
+    if (unlikely(!nstr || !ws_string_set_from_str(nstr, self))) {
         return NULL;
     }
 
@@ -250,7 +250,7 @@ ws_string_raw(
     }
 
     char* output = calloc(dest_len + 1, sizeof(*output)); // +1 => Nullbyte
-    if (!output) {
+    if (unlikely(!output)) {
         return NULL;
     }
 
@@ -273,7 +273,7 @@ ws_string_set_from_raw(
     struct ws_string* self,
     char* raw
 ){
-    if (!self) {
+    if (unlikely(!self)) {
         return -EINVAL;
     }
 
@@ -289,7 +289,7 @@ ws_string_set_from_raw(
     // allocate buffer
     ++len;
     UChar* conv_raw = calloc(1, sizeof(*conv_raw) * len);
-    if (!conv_raw) {
+    if (unlikely(!conv_raw)) {
         return -ENOMEM;
     }
 
@@ -319,7 +319,7 @@ static bool
 deinit_callback(
     struct ws_object* const self
 ) {
-    if (self) {
+    if (likely(self)) {
         free(((struct ws_string*) self)->str);
         return true;
     }

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -100,16 +100,14 @@ ws_string_set_from_str(
     ws_object_lock_write(&self->obj);
     ws_object_lock_read(&other->obj);
 
-    UChar* temp;
     size_t charcount = u_strlen(other->str);
 
-    temp = realloc(self->str, (charcount + 1) * sizeof(*self->str));
+    UChar* temp = realloc(self->str, (charcount + 1) * sizeof(*self->str));
     if (!temp) {
         ws_object_unlock(&other->obj);
         ws_object_unlock(&self->obj);
         return false;
     }
-    
     self->str = temp;
 
     self->str = u_strcpy(self->str, other->str);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -248,8 +248,7 @@ ws_string_raw(
         return NULL;
     }
 
-    char* output;
-    output = calloc(dest_len + 1, sizeof(*output)); // +1 => Nullbyte
+    char* output = calloc(dest_len + 1, sizeof(*output)); // +1 => Nullbyte
     if (!output) {
         return NULL;
     }
@@ -303,7 +302,6 @@ ws_string_set_from_raw(
     ws_object_lock_write(&self->obj);
 
     free(self->str);
-
     self->str = conv_raw;
 
     ws_object_unlock(&self->obj);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -206,12 +206,10 @@ ws_string_ncmp(
     size_t offset,
     size_t n
 ){
-    int res;
-
     ws_object_lock_read(&self->obj);
     ws_object_lock_read(&other->obj); //!< @todo Thread-safeness!
 
-    res = u_strncmp(self->str + offset, other->str, n);
+    int res = u_strncmp(self->str + offset, other->str, n);
 
     ws_object_unlock(&self->obj);
     ws_object_unlock(&other->obj);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -222,11 +222,10 @@ ws_string_substr(
     struct ws_string* self,
     struct ws_string* other
 ){
-    UChar* res;
     ws_object_lock_read(&self->obj);
     ws_object_lock_read(&other->obj); //!< @todo Thread-safeness!
 
-    res = u_strstr(self->str, other->str);
+    UChar* res = u_strstr(self->str, other->str);
 
     ws_object_unlock(&self->obj);
     ws_object_unlock(&other->obj);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -111,7 +111,7 @@ ws_string_set_from_str(
     }
     self->str = temp;
 
-    self->str = u_strcpy(self->str, other->str);
+    u_strcpy(self->str, other->str);
 
     ws_object_unlock(&other->obj);
     ws_object_unlock(&self->obj);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -188,12 +188,10 @@ ws_string_cmp(
     struct ws_string* self,
     struct ws_string* other
 ){
-    int res;
-
     ws_object_lock_read(&self->obj);
     ws_object_lock_read(&other->obj); //!< @todo Thread-safeness!
 
-    res = u_strcmp(self->str, other->str);
+    int res = u_strcmp(self->str, other->str);
 
     ws_object_unlock(&other->obj);
     ws_object_unlock(&self->obj);

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -244,7 +244,7 @@ ws_string_raw(
     UErrorCode err = U_ZERO_ERROR;
     size_t charcount = u_strlen(self->str);
 
-    (void) u_strToUTF8(NULL, 0, &dest_len, self->str, charcount, &err);
+    u_strToUTF8(NULL, 0, &dest_len, self->str, charcount, &err);
     if ((err != U_BUFFER_OVERFLOW_ERROR) && U_FAILURE(err)) {
         return NULL;
     }
@@ -281,7 +281,7 @@ ws_string_set_from_raw(
 
     // get the length of the buffer to allocate
     int32_t len;
-    (void) u_strFromUTF8(NULL, 0, &len, raw, -1, &err);
+    u_strFromUTF8(NULL, 0, &len, raw, -1, &err);
     if ((err != U_BUFFER_OVERFLOW_ERROR) && U_FAILURE(err)) {
         return -ENOMEM; //!< @todo is it actually -ENOMEM?
     }

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -176,17 +176,11 @@ ws_string_dupl(
     struct ws_string* self
 ){
     struct ws_string* nstr = ws_string_new();
-
-    if (nstr) {
-        bool res;
-        res = ws_string_set_from_str(nstr, self);
-
-        if (res) {
-            return nstr;
-        }
+    if (!nstr || !ws_string_set_from_str(nstr, self)) {
+        return NULL;
     }
 
-    return NULL;
+    return nstr;
 }
 
 int

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -116,7 +116,7 @@ ws_string_set_from_str(
     ws_object_unlock(&other->obj);
     ws_object_unlock(&self->obj);
 
-    return !!self->str;
+    return true;
 }
 
 struct ws_string*

--- a/src/objects/string.h
+++ b/src/objects/string.h
@@ -195,8 +195,10 @@ ws_string_raw(
  * Set the string contained in a ws_string object to the passed UTF8 string
  *
  * @memberof ws_string
+ *
+ * @return 0 on success, else negative errno number
  */
-void
+int
 ws_string_set_from_raw(
     struct ws_string* self,
     char* raw

--- a/src/serialize/json/deserializer_callbacks.c
+++ b/src/serialize/json/deserializer_callbacks.c
@@ -372,7 +372,11 @@ yajl_string_cb(
                 return 0;
             }
             struct ws_string* str = ws_value_string_get(s);
-            ws_string_set_from_raw(str, buff);
+            int res = ws_string_set_from_raw(str, buff);
+            if (res != 0) {
+                //!< @todo indicate error
+                return 0;
+            }
 
             free(buff); // ws_string_set_from_raw() copies.
 
@@ -398,7 +402,11 @@ yajl_string_cb(
             memset(buff, 0, len + 1);
             strncpy(buff, (char*)str, len);
 
-            ws_string_set_from_raw(state->register_name, buff);
+            int res = ws_string_set_from_raw(state->register_name, buff);
+            if (res != 0) {
+                //!< @todo indicate error
+                return 0;
+            }
 
             state->flags |= WS_TRANSACTION_FLAGS_REGISTER;
             state->current_state = STATE_FLAGS_MAP;
@@ -418,7 +426,11 @@ yajl_string_cb(
             char buff[len + 1];
             memset(buff, 0, len + 1);
             strncpy(buff, (char*) str, len);
-            ws_string_set_from_raw(state->ev_name, buff);
+            int res = ws_string_set_from_raw(state->ev_name, buff);
+            if (res != 0) {
+                //!< @todo indicate error
+                return 0;
+            }
             // ready for now.
 
             state->current_state = STATE_MSG;
@@ -446,7 +458,11 @@ yajl_string_cb(
             char buff[len + 1];
             memset(buff, 0, len + 1);
             strncpy(buff, (char*) str, len);
-            ws_string_set_from_raw(sstr, buff);
+            int res = ws_string_set_from_raw(sstr, buff);
+            if (res != 0) {
+                //!< @todo indicate error
+                return 0;
+            }
 
             ws_value_string_set_str(s, sstr);
             state->ev_ctx = (struct ws_value*) s;


### PR DESCRIPTION
This PR is a cleanup for the ws_string type implementation,
it removes whitespace, simplifies some algorithms and does
one major change: The return type of
ws_string_set_from_raw(). It adapts the calls to
this function, though.

This was pair-programmed with @manuelmessner.
