### PR TITLE
Fix refcounting in object

### DIFF
--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -192,7 +192,7 @@ struct ws_object {
     ws_object_type_id* id;        //!< Object id, identifies the actual type
 
     struct {
-        pthread_rwlock_t rwl;
+        pthread_mutex_t lock;
         size_t refcnt;
     } ref_counting; //!< @private Ref counting
 


### PR DESCRIPTION
Previously, we had a lock for refcounting but didn't use it _at all_.
This commit introduces proper recount-locking and thus fixes a _lot_ of
potential issues.

Targets #495.
