### PR TITLE
Fix: Add missing uuid callback NULLing in wayland client type

### DIFF
--- a/src/compositor/wayland/client.c
+++ b/src/compositor/wayland/client.c
@@ -76,6 +76,7 @@ ws_object_type_id WS_OBJECT_TYPE_ID_WAYLAND_CLIENT = {
     .hash_callback = hash_callback,
     .deinit_callback = NULL,
     .cmp_callback = cmp_callback,
+    .uuid_callback = NULL,
 
     .attribute_table = NULL,
     .function_table = NULL,


### PR DESCRIPTION
I'm ready here.
