### PR TITLE
Ignore event spams of keys we already have

### DIFF
--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -174,8 +174,13 @@ ws_hotkey_dag_next(
     }
 
     struct ws_hotkey_dag_tab cur = node->table;
-
     uint16_t step = DAG_TAB_CHILD_NUM_EXP * cur.depth;
+
+    // check whether the code is in the range covered by the tree
+    if ((code < cur.start) ||
+            (((code - cur.start) >> step) >= DAG_TAB_CHILD_NUM)) {
+        return NULL;
+    }
 
     // move towards the bottom
     while (cur.depth-- && cur.nodes.tab) {

--- a/src/input/hotkeys.c
+++ b/src/input/hotkeys.c
@@ -118,9 +118,27 @@ ws_hotkeys_eval(
     // get the key code
     uint16_t code = ev->code;
 
-    // insert the event into the track list
+    // insert the event into the track list, if it's not yet in the event list
     {
         struct input_event* buf;
+
+        // check whether the event already is accounted for
+        struct input_event* const data = ws_hotkeys_ctx.events.data;
+        buf = data + ws_hotkeys_ctx.events.size;
+        while (buf-- > data) {
+            if (buf->code != code) {
+                // event not of interest
+                continue;
+            }
+            if (buf->value != ev->value) {
+                // the button was release before
+                break;
+            }
+            // we consume the event but we'll _not_ store it or iterate the DAG
+            return empty_eventlist();
+        }
+
+        // now insert the event into the event list
         buf = wl_array_add(&ws_hotkeys_ctx.events, sizeof(*ev));
         if (!buf) {
             return eventlist_reset();

--- a/src/input/hotkeys.c
+++ b/src/input/hotkeys.c
@@ -169,6 +169,12 @@ ws_hotkeys_eval(
         return empty_eventlist();
     }
 
+    // check whether we are intereset in this key release event at all
+    if (ws_hotkeys_ctx.buttons_pressed == 0) {
+        // we a re currently not tracking a key-combo
+        return eventlist_reset();
+    }
+
     // check whether we just removed the last key
     --ws_hotkeys_ctx.buttons_pressed;
     if (ws_hotkeys_ctx.buttons_pressed > 0) {


### PR DESCRIPTION
This PR fixes a bug where keeping a key down for a while causes the DAG not to be traverses correctly.
