### PR TITLE
Fix exec

### DIFF
--- a/src/util/exec.c
+++ b/src/util/exec.c
@@ -48,7 +48,7 @@ ws_exec(
     if (pid == 0) {
         // child, now exec()
         if (execvp(call, argv) == -1) {
-            return -errno;
+            exit(errno);
         }
     }
 

--- a/src/util/exec.c
+++ b/src/util/exec.c
@@ -46,7 +46,15 @@ ws_exec(
     }
 
     if (pid == 0) {
-        // child, now exec()
+        // we're the child. We should drop our privileges first
+        if (seteuid(getuid()) < 0) {
+            exit(errno);
+        }
+        if (setegid(getgid()) < 0) {
+            exit(errno);
+        }
+
+        // now execvp()
         if (execvp(call, argv) == -1) {
             exit(errno);
         }


### PR DESCRIPTION
Our exec code had a few issues.
For example, the effective user id and group id were not reset, which is generally bad. Resettign them means that we can solve the whole need-to-be-in-"input"-group-issue by setting the set-group-ID bit on installation and setting the group of the executable to "input", whithout having forked processed be able to read from `/dev/input/*`.
