### PR TITLE
Initialize command and flag fields of transactions

### DIFF
--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -95,6 +95,8 @@ ws_transaction_init(
     self->m.obj.id = &WS_OBJECT_TYPE_ID_TRANSACTION;
 
     self->name = getref(name);
+    self->cmds = NULL;
+    self->flags = 0;
     return 0;
 }
 

--- a/src/objects/message/transaction.c
+++ b/src/objects/message/transaction.c
@@ -254,9 +254,9 @@ deinit_transaction(
     while (statement--) {
         ws_statement_deinit(&t->cmds->statements[statement]);
     }
+    t->cmds->num = 0;
 
 out:
-    t->cmds->num = 0;
     ws_object_unlock(self);
     return true;
 }


### PR DESCRIPTION
This commit adds initialization codes for fields which were left
uninitialized before, potentially leading to segfaults.
