### PR TITLE
Rewrite func_log()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(waysome
     logger
 
     ${EV_LIBRARIES}
+    m
 )
 
 

--- a/src/logger/module.c
+++ b/src/logger/module.c
@@ -153,8 +153,23 @@ ws_log_ary(
     int lvl,
     char** ary
 ) {
-    //!< @todo implement
-    return;
+    if (lvl > runtime_log_lvl) {
+        return;
+    }
+
+    pthread_mutex_lock(&logger.loglock);
+
+    if (ctx) {
+        fprintf(stderr, "%s", ctx->prefix);
+    }
+
+    while (*ary) {
+        fprintf(stderr, "%s", *ary);
+        ++ary;
+    }
+    fprintf(stderr, "\n");
+
+    pthread_mutex_unlock(&logger.loglock);
 }
 
 /*

--- a/src/logger/module.c
+++ b/src/logger/module.c
@@ -147,6 +147,16 @@ ws_log(
     va_end(list);
 }
 
+void
+ws_log_ary(
+    struct ws_logger_context* const ctx,
+    int lvl,
+    char** ary
+) {
+    //!< @todo implement
+    return;
+}
+
 /*
  * void
  * ws_log_str(

--- a/src/logger/module.h
+++ b/src/logger/module.h
@@ -66,6 +66,18 @@ ws_log(
     ...         //!< Additional parameters
 );
 
+/**
+ * Log an null-terminated array of strings with a logger
+ *
+ * @note `ctx` can be NULL
+ */
+void
+ws_log_ary(
+    struct ws_logger_context* const ctx, //!< The logging context
+    int lvl, //!< Logging level
+    char** ary //!< ary to log
+);
+
 /*
  * void
  * ws_log_str(

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -53,6 +53,10 @@
 #define ws_strneq(str1, str2, n) \
     (0 == strncmp((str1), (str2), (n)))
 
+/**
+ * Convert a hardcoded int to string
+ */
+#define STR_OF(x) (#x)
 
 #endif // __WS_UTIL_STRING_H__
 

--- a/src/values/union.c
+++ b/src/values/union.c
@@ -26,9 +26,11 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "values/union.h"
 #include "values/value_type.h"
+#include "util/string.h"
 
 int
 ws_value_union_init_from_val(
@@ -130,4 +132,99 @@ ws_value_union_reinit(
     return 0;
 }
 
+char*
+ws_value_union_tostr(
+    union ws_value_union* self
+) {
+    char* res = NULL;
+
+    switch (ws_value_get_type(&self->value)) {
+    case WS_VALUE_TYPE_NONE:
+        {
+            static const char* none = "<none>";
+            res = malloc(strlen(none) + 1);
+            if (!res) {
+                return NULL;
+            }
+            res[strlen(none)] = 0;
+            memcpy(res, none, strlen(none));
+        }
+        break;
+
+    case WS_VALUE_TYPE_VALUE:
+        {
+            static const char* value = "<value>";
+            res = malloc(strlen(value) + 1);
+            if (!res) {
+                return NULL;
+            }
+            res[strlen(value)] = 0;
+            memcpy(res, value, strlen(value));
+        }
+        break;
+
+    case WS_VALUE_TYPE_NIL:
+        {
+            static const char* nil = "<nil>";
+            res = malloc(strlen(nil) + 1);
+            if (!res) {
+                return NULL;
+            }
+            res[strlen(nil)] = 0;
+            memcpy(res, nil, strlen(nil));
+        }
+        break;
+
+    case WS_VALUE_TYPE_BOOL:
+        {
+            bool b = ws_value_bool_get(&self->bool_);
+            char* bstr = (b ? "true" : "false");
+            res = malloc(strlen(bstr) + 1);
+            if (!res) {
+                return NULL;
+            }
+            res[strlen(bstr)] = 0;
+            memcpy(res, bstr, strlen(bstr));
+        }
+        break;
+
+    case WS_VALUE_TYPE_INT:
+            {
+                size_t strl = strlen(STR_OF(INTMAX_MAX));
+                intmax_t j  = ws_value_int_get(&self->int_);
+                res = calloc(1, strl + 1);
+                if (!res) {
+                    return NULL;
+                }
+                snprintf(res, strl, "%ld", j);
+            }
+            break;
+
+    case WS_VALUE_TYPE_STRING:
+            {
+                struct ws_string* sstr  = ws_value_string_get(&self->string);
+                char* s = ws_string_raw(sstr);
+                size_t len = strlen(s) + 1;
+                res = malloc(len);
+                if (res) {
+                    snprintf(res, len, "%s", s);
+                }
+                free(s);
+            }
+            break;
+
+    case WS_VALUE_TYPE_OBJECT_ID:
+            //!< @todo implement
+            break;
+
+    case WS_VALUE_TYPE_SET:
+            //!< @todo implement
+            break;
+
+    default:
+            break;
+    }
+
+    return res;
+}
 

--- a/src/values/union.h
+++ b/src/values/union.h
@@ -91,6 +91,17 @@ ws_value_union_reinit(
 __ws_nonnull__(1)
 ;
 
+/**
+ * Generate string representation of value union
+ *
+ * @note Returns char* which can and should be freed after usage
+ *
+ * @return string representation of value union, NULL on failure
+ */
+char*
+ws_value_union_tostr(
+    union ws_value_union* self //!< The union to convert to char*
+);
 
 #endif //__WS_VALUES_UNION_H__
 


### PR DESCRIPTION
This PR completely rewrites the func_log() function to be able to
parse `ws_value_*` types into their string representation and log them.

Pair-programmed-with: ~~Marcel Müller com2040@gmail.com~~ @TheNeikos 
Suggested-by: ~~Marcel Müller com2040@gmail.com~~ @TheNeikos 
