### PR TITLE
Remove WS_VALUE_TYPE_NAMED zombies

### DIFF
--- a/src/command/util.h
+++ b/src/command/util.h
@@ -61,7 +61,6 @@
 #define WS_VALUE_TYPE_string    WS_VALUE_TYPE_STRING
 #define WS_VALUE_TYPE_object_id WS_VALUE_TYPE_OBJECT_ID
 #define WS_VALUE_TYPE_set       WS_VALUE_TYPE_SET
-#define WS_VALUE_TYPE_named     WS_VALUE_TYPE_NAMED
 
 
 /**

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -503,10 +503,6 @@ serialize_value(
                 stat = yajl_gen_array_close(ctx->yajlgen);
                 break;
 
-            case WS_VALUE_TYPE_NAMED:
-                //!< @todo support this
-                break;
-
             default:
                 //!< @todo error?
                 return -1;

--- a/src/values/value_type.h
+++ b/src/values/value_type.h
@@ -46,7 +46,6 @@ enum ws_value_type {
     WS_VALUE_TYPE_STRING,
     WS_VALUE_TYPE_OBJECT_ID,
     WS_VALUE_TYPE_SET,
-    WS_VALUE_TYPE_NAMED,
 };
 
 extern const char* WS_VALUE_TYPE_NAMES[];


### PR DESCRIPTION
We removed this type earlier this week, but I forgot to remove these
code fragments.
