### PR TITLE
Fix clang warning by using size_t and not enumerator type

### DIFF
--- a/src/values/value_type.c
+++ b/src/values/value_type.c
@@ -54,7 +54,7 @@ enum ws_value_type
 ws_value_type_from_value_name(
     char const* name
 ) {
-    for (enum ws_value_type i = 0; i < ARYLEN(WS_VALUE_TYPE_NAMES); i++) {
+    for (size_t i = 0; i < ARYLEN(WS_VALUE_TYPE_NAMES); i++) {
         if (ws_streq(WS_VALUE_TYPE_NAMES[i], name)) {
             return i;
         }


### PR DESCRIPTION
Targets #557.
