### PR TITLE
Fixed uuid generation for ws_wayland_obj

### DIFF
--- a/src/objects/wayland_obj.c
+++ b/src/objects/wayland_obj.c
@@ -184,5 +184,6 @@ uuid_callback(
     struct ws_object* self
 ) {
     struct ws_wayland_obj* o = (struct ws_wayland_obj*) self;
-    return (uintmax_t) wl_resource_get_id(o->resource);
+    return ((uintmax_t) wl_resource_get_id(o->resource)) +
+           ((uintmax_t) self);
 }


### PR DESCRIPTION
The reason for this fix is because the resource id is _local per client_. So
if the same client connects twice (two instances of the same exec) they will
get the same ids!
