### PR TITLE
Add missing state reset on event emission

### DIFF
--- a/src/input/hotkeys.c
+++ b/src/input/hotkeys.c
@@ -200,6 +200,7 @@ ws_hotkeys_eval(
     }
 
     // reset the eventlist
+    ws_hotkeys_ctx.state = NULL;
     wl_array_release(&ws_hotkeys_ctx.events);
     wl_array_init(&ws_hotkeys_ctx.events);
     ws_hotkeys_ctx.buttons_pressed = 0;


### PR DESCRIPTION
When eimitting an event, we also have to reset the state.
