### PR TITLE
Fixup of variable declaration

### DIFF
--- a/src/compositor/wayland/xdg_surface.c
+++ b/src/compositor/wayland/xdg_surface.c
@@ -354,7 +354,6 @@ ws_wayland_xdg_surface_new(
     struct ws_wayland_xdg_surface* self = calloc(1, sizeof(*self));
     if (!self) {
         goto cleanup_wayland;
-        return NULL;
     }
 
     int retval;
@@ -362,7 +361,6 @@ ws_wayland_xdg_surface_new(
                                             &xdg_surface_interface);
     if (retval < 0) {
         goto cleanup;
-        return NULL;
     }
 
     wl_resource_set_implementation(resource, &interface, self, NULL);

--- a/src/context.c
+++ b/src/context.c
@@ -241,17 +241,19 @@ func_exec(
 
     // copy over all the strings
     size_t i = n;
+    int res = 0;
     while (i) {
         --i;
         struct ws_string* arg = ws_value_string_get(&stack[i].string);
         if (!arg) {
+            res = -ENOENT;
             goto cleanup;
         }
         args[i] = ws_string_raw(arg);
     }
 
     // perform the exec
-    int res = ws_exec(args[0], (char**)args);
+    res = ws_exec(args[0], (char**)args);
 
 cleanup:
     // free all the strings we did set


### PR DESCRIPTION
The content of the variable `res` will be returned but it was never
declared (goto case).
