### PR TITLE
Remove `@todos` in object code

### DIFF
--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -458,8 +458,7 @@ ws_object_attr_read(
         break;
 
     default:
-        //!< @todo Something strange happened in this case, maybe implementation
-        // missing here. What to do now?
+        ws_log(&log_ctx, LOG_EMERG, "Unhandleable value type identifier");
         break;
     };
 


### PR DESCRIPTION
This PR removes `@todo`s from the src/objects subdir.

Related to #467 and #584 (as I would include removal of the
double-type code stuff in this PR)
