### PR TITLE
Remove @todo, fix a small bug in connection processor

### DIFF
--- a/src/connection/connbuf.c
+++ b/src/connection/connbuf.c
@@ -139,3 +139,10 @@ ws_connbuf_discard(
     return 0;
 }
 
+char*
+ws_connbuf_buffer(
+    struct ws_connbuf* self
+) {
+    return (self ? self->buffer : NULL);
+}
+

--- a/src/connection/connbuf.c
+++ b/src/connection/connbuf.c
@@ -146,3 +146,9 @@ ws_connbuf_buffer(
     return (self ? self->buffer : NULL);
 }
 
+size_t
+ws_connbuf_data(
+    struct ws_connbuf* self //!< The object
+) {
+    return (self ? self->data : 0);
+}

--- a/src/connection/connbuf.h
+++ b/src/connection/connbuf.h
@@ -200,6 +200,18 @@ ws_connbuf_buffer(
     struct ws_connbuf* self //!< The object
 );
 
+/**
+ * Get the amount of the used memory
+ *
+ * @memberof ws_connbuf
+ *
+ * @return amount of used memory or zero on failure
+ */
+size_t
+ws_connbuf_data(
+    struct ws_connbuf* self //!< The object
+);
+
 #endif // __WS_CONNBUF_H__
 
 /**

--- a/src/connection/connbuf.h
+++ b/src/connection/connbuf.h
@@ -188,6 +188,18 @@ ws_connbuf_discard(
     size_t amount //!< the amount of memory to release
 );
 
+/**
+ * Get the buffer from the ws_connbuf object
+ *
+ * @memberof ws_connbuf
+ *
+ * @return buffer char* or NULL on failure
+ */
+char*
+ws_connbuf_buffer(
+    struct ws_connbuf* self //!< The object
+);
+
 #endif // __WS_CONNBUF_H__
 
 /**

--- a/src/connection/processor.c
+++ b/src/connection/processor.c
@@ -275,7 +275,7 @@ connection_processor_dispatch(
     }
 
 error_handling:
-    switch(-res) {
+    switch(res) {
     case -EAGAIN:
     case -EINTR:
         // we have to come back later

--- a/src/connection/processor.c
+++ b/src/connection/processor.c
@@ -234,9 +234,9 @@ connection_processor_dispatch(
     struct ws_message* msg = NULL;
     while (1) {
         // deserialize a message
-        //!< @todo use getters as soon as they are available
-        res =  ws_deserialize(proc->deserializer, &msg,
-                              proc->conn.inbuf.buffer, proc->conn.inbuf.data);
+        res = ws_deserialize(proc->deserializer, &msg,
+                             ws_connbuf_buffer(&proc->conn.inbuf),
+                             ws_connbuf_data(&proc->conn.inbuf));
         if (res < 0) {
             break;
         }


### PR DESCRIPTION
This PR removes a `@todo` from the connection processor and fixes a
small bug in the code of the same file.

Related to #467.
