### PR TITLE
Fix: Add missing memset() calls

### DIFF
--- a/src/action/manager.c
+++ b/src/action/manager.c
@@ -142,6 +142,8 @@ ws_action_manager_process(
 ) {
     struct ws_value* vctx = NULL;
     struct ws_value_object_id ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
     if (opt_ctx) {
         ws_value_object_id_init(&ctx);
         ws_value_object_id_set(&ctx, opt_ctx);
@@ -208,6 +210,7 @@ ws_action_manager_process(
         if (!transaction) {
             // get the transaction directly
             struct ws_transaction comparable;
+            memset(&comparable, 0, sizeof(comparable));
             if (ws_transaction_init(&comparable, 0, name) < 0) {
                 goto cleanup_name;
             }
@@ -247,6 +250,8 @@ ws_action_manager_register(
 
     // get the transaction
     struct ws_transaction comparable;
+    memset(&comparable, 0, sizeof(comparable));
+
     res = ws_transaction_init(&comparable, 0, transaction_name);
     if (res < 0) {
         return res;
@@ -284,6 +289,8 @@ ws_action_manager_unregister_event(
 
     // construct a comparable for removal
     struct ws_named comparable;
+    memset(&comparable, 0, sizeof(comparable));
+
     res = ws_named_init(&comparable, event_name, NULL);
     if (res < 0) {
         return res;
@@ -306,6 +313,7 @@ ws_action_manager_unregister_transaction(
 
     // construct a comparable for removal
     struct ws_transaction comparable;
+    memset(&comparable, 0, sizeof(comparable));
     res = ws_transaction_init(&comparable, 0, transaction_name);
     if (res < 0) {
         return res;
@@ -338,6 +346,8 @@ run_transaction(
 
     // prepare the stack
     struct ws_processor_stack stack;
+    memset(&stack, 0, sizeof(stack));
+
     res = ws_processor_stack_init(&stack);
     if (res < 0) {
         retval = (struct ws_reply*)
@@ -395,6 +405,8 @@ run_transaction(
 
     // prepare the processor
     struct ws_processor proc;
+    memset(&proc, 0, sizeof(proc));
+
     res = ws_processor_init(&proc, &stack, commands);
     if (res < 0) {
         retval = (struct ws_reply*)

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -279,6 +279,8 @@ ws_hotkey_dag_remove(
 
     // get the point where we may start the removal and commence destruction!
     struct ws_hotkey_dag_tab tab;
+    memset(&tab, 0, sizeof(tab));
+
     tab = removal_point_in_tab_node(last_keep->table, rem_code);
     if (tab.nodes.tab) {
         // we have a node to return
@@ -443,6 +445,7 @@ removal_point_in_tab_node(
 ) {
     // prepare the return value
     struct ws_hotkey_dag_tab retval;
+    memset(&retval, 0, sizeof(retval));
     retval.nodes.tab = NULL;
     retval.depth = ~0;
 

--- a/src/input/hotkeys.c
+++ b/src/input/hotkeys.c
@@ -30,6 +30,7 @@
 #include <malloc.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "action/manager.h"
 #include "input/hotkey_dag.h"
@@ -230,8 +231,12 @@ ws_hotkey_remove(
 
     // construct an event for the removal
     struct ws_string name;
+    memset(&name, 0, sizeof(name));
     ws_string_init(&name);
+
     struct ws_hotkey_event event;
+    memset(&event, 0, sizeof(event));
+
     res = ws_hotkey_event_init(&event, &name, codes, code_num);
     if (res < 0) {
         return res;


### PR DESCRIPTION
This PR adds some missing memset() calls when allocating memory on the
stack, which is exaclty the bug which causes a segfault on the latest
develop.
