### PR TITLE
Call ws_errno_tostr() in action manager error reply building

### DIFF
--- a/src/action/manager.c
+++ b/src/action/manager.c
@@ -40,6 +40,7 @@
 #include "objects/named.h"
 #include "objects/set.h"
 #include "util/cleaner.h"
+#include "util/error.h"
 
 
 /**
@@ -418,10 +419,9 @@ run_transaction(
     // run processor
     res = ws_processor_exec(&proc);
     if (res < 0) {
-        //!< @todo more elaborate error description
+        const char* errmsg = ws_errno_tostr(res);
         retval = (struct ws_reply*)
-                 ws_error_reply_new(transaction, -res,
-                                    "Could not exec transaction", NULL);
+                 ws_error_reply_new(transaction, -res, errmsg, NULL);
         goto cleanup_processor;
     }
 

--- a/src/objects/string.c
+++ b/src/objects/string.c
@@ -271,7 +271,7 @@ ws_string_raw(
 int
 ws_string_set_from_raw(
     struct ws_string* self,
-    char* raw
+    const char* raw
 ){
     if (unlikely(!self)) {
         return -EINVAL;

--- a/src/objects/string.h
+++ b/src/objects/string.h
@@ -207,7 +207,7 @@ ws_string_raw(
 int
 ws_string_set_from_raw(
     struct ws_string* self,
-    char* raw
+    const char* raw
 );
 
 

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -33,26 +33,25 @@
 #include "util/condition.h"
 #include "util/error.h"
 
-char*
+const char*
 ws_errno_tostr(
     int errnr
 ) {
-    char* errstr = strerror(ABS(errnr));
-    return (errstr ? strdup(errstr) : NULL);
+    return strerror(ABS(errnr));
 }
 
 struct ws_value_string*
 ws_errno_to_value_string(
     int errno
 ) {
-    char* errstr = ws_errno_tostr(errno);
+    const char* errstr = ws_errno_tostr(errno);
     if (!errstr) {
         return NULL;
     }
 
     struct ws_value_string* res = ws_value_string_new();
     if (unlikely(!res)) {
-        goto cleanup_errstr;
+        goto out;
     }
 
     struct ws_string* s = ws_value_string_get(res);
@@ -69,9 +68,6 @@ ws_errno_to_value_string(
 cleanup_values:
     ws_value_deinit((struct ws_value*) res);
     res = NULL;
-
-cleanup_errstr:
-    free(errstr);
 
 out:
     return res;

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -35,9 +35,9 @@
 
 char*
 ws_errno_tostr(
-    int errno
+    int errnr
 ) {
-    char* errstr = strerror(ABS(errno));
+    char* errstr = strerror(ABS(errnr));
     return (errstr ? strdup(errstr) : NULL);
 }
 

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -54,7 +54,7 @@
  */
 char*
 ws_errno_tostr(
-    int errno
+    int errnr
 );
 
 /**

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -43,16 +43,16 @@
 /**
  * Translate an errno number to a char*.
  *
- * @note Both positive and negative errno values can be passed
+ * @warning The returned value can't be free()'d afterwards
  *
- * @note The returned value can be free()'d afterwards
+ * @note Both positive and negative errno values can be passed
  *
  * @note This function will change later on, to be able to translate custom
  * errno number to sane error strings. Its interface won't change, though.
  *
  * @return Error description for the errno passed, NULL on failure (no memory)
  */
-char*
+const char*
 ws_errno_tostr(
     int errnr
 );


### PR DESCRIPTION
Partly targets #467 and removes the `@todo` from `src/action/manager.c`.
Anyways, the introduced changes may be discussed.
