### PR TITLE
Rip logging contexts of compositor apart

### DIFF
--- a/src/compositor/buffer/buffer.c
+++ b/src/compositor/buffer/buffer.c
@@ -33,6 +33,8 @@
 #include "util/arithmetical.h"
 #include "util/egl.h"
 
+static struct ws_logger_context log_ctx = { .prefix = "[Compositor/Buffer] " };
+
 ws_buffer_type_id WS_OBJECT_TYPE_ID_BUFFER = {
     .type = {
         .supertype  = &WS_OBJECT_TYPE_ID_OBJECT,

--- a/src/compositor/buffer/frame.c
+++ b/src/compositor/buffer/frame.c
@@ -42,6 +42,7 @@
 #include "compositor/buffer/raw_buffer.h"
 #include "compositor/internal_context.h"
 
+static struct ws_logger_context log_ctx = { .prefix = "[Compositor/Frame] " };
 
 /*
  *

--- a/src/compositor/cursor.c
+++ b/src/compositor/cursor.c
@@ -45,6 +45,8 @@
 #include "compositor/wayland/region.h"
 #include "util/wayland.h"
 
+static struct ws_logger_context log_ctx = { .prefix = "[Compositor/Cursor] " };
+
 #define CURSOR_SIZE 64
 
 /**

--- a/src/compositor/framebuffer_device.c
+++ b/src/compositor/framebuffer_device.c
@@ -40,6 +40,9 @@
 #include "logger/module.h"
 #include "objects/object.h"
 
+static struct ws_logger_context log_ctx = {
+    .prefix = "[Compositor/FBDevice] "
+};
 
 /*
  *

--- a/src/compositor/internal_context.h
+++ b/src/compositor/internal_context.h
@@ -51,10 +51,6 @@ extern struct ws_compositor_context {
     struct ws_keyboard* keyboard; //!< The keyboard
 } ws_comp_ctx;
 
-// We make the object available for others to use
-extern struct ws_logger_context log_ctx;
-
-
 #endif // __WS_COMPOSITOR_INTERNAL_CONTEXT_H__
 
 /**

--- a/src/compositor/module.c
+++ b/src/compositor/module.c
@@ -56,7 +56,7 @@
 #include "util/wayland.h"
 
 struct ws_compositor_context ws_comp_ctx;
-struct ws_logger_context log_ctx = { .prefix = "[Compositor] " };
+static struct ws_logger_context log_ctx = { .prefix = "[Compositor] " };
 
 
 /**

--- a/src/compositor/monitor.c
+++ b/src/compositor/monitor.c
@@ -45,6 +45,8 @@
 #include "objects/object.h"
 #include "util/wayland.h"
 
+static struct ws_logger_context log_ctx = { .prefix = "[Compositor/Monitor] " };
+
 /*
  *
  *  Forward declarations


### PR DESCRIPTION
This PR tears the logging contexts of the compositor in smaller pieces
(each part of the compositor has another logging context now).
