### PR TITLE
Add object attribute writing

### DIFF
--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -478,6 +478,24 @@ __ws_nonnull__(1, 2, 3)
 ;
 
 /**
+ * Write an attribute of an object
+ *
+ * @memberof wes_object
+ *
+ * How it works: \see ws_object_attr_read
+ *
+ * @return zero on success, else negative errno.h number
+ */
+int
+ws_object_attr_write(
+    struct ws_object* self, //!< The object
+    char const* ident, //!< The identifier for the attribute
+    struct ws_value* src //!< Source of the data
+)
+__ws_nonnull__(1, 2, 3)
+;
+
+/**
  * Get the type of an attribute identified by its name
  *
  * @memberof ws_object

--- a/tests/check/objects/ws_object/attribute_test.c
+++ b/tests/check/objects/ws_object/attribute_test.c
@@ -173,3 +173,22 @@ START_TEST (test_object_attribute_read) {
     ws_object_unref(&to->obj);
 }
 END_TEST
+
+START_TEST (test_object_attribute_write) {
+    struct ws_test_object* to = ws_test_object_new();
+    ck_assert(to);
+
+    struct ws_value_int* v = NULL;
+    int r = TEST_INT + 5;
+    v = calloc(1, sizeof(*v));
+
+    ws_value_int_init(v);
+    ws_value_int_set(v, r);
+    ck_assert(to->int_attribute == TEST_INT);
+    ws_object_attr_write(&to->obj, "int", &v->value);
+    ck_assert(to->int_attribute == r);
+
+    free(v);
+    ws_object_unref(&to->obj);
+}
+END_TEST

--- a/tests/check/objects/ws_object/test.c
+++ b/tests/check/objects/ws_object/test.c
@@ -211,6 +211,7 @@ objects_suite(void)
 
     tcase_add_test(tca, test_object_attribute_type);
     tcase_add_test(tca, test_object_attribute_read);
+    tcase_add_test(tca, test_object_attribute_write);
 
     return s;
 }


### PR DESCRIPTION
This is a preparation PR for a HUGE refactoring I'm working on.

Using this, we can refactor the whole abstract shell surface attribute
handling (for example, I'd bet half of the chocolate I will receive on
christmas that there are much more locations we can use this) and
remove quite a big bunch of code in favour of abstraction.

Please review carefully and provide me your suggestions.
