### PR TITLE
Refactor attribute accessors

### DIFF
--- a/src/command/object.c
+++ b/src/command/object.c
@@ -184,6 +184,37 @@ out:
 }
 
 int
+ws_builtin_cmd_set_attr(
+    union ws_value_union* args
+) {
+    if ((args[0].value.type != WS_VALUE_TYPE_OBJECT_ID) ||
+        (args[1].value.type != WS_VALUE_TYPE_STRING) ||
+        (args[2].value.type == WS_VALUE_TYPE_NONE)) {
+        return -EINVAL;
+    }
+
+    int res = -EINVAL;
+
+    struct ws_object* obj = ws_value_object_id_get(&args[0].object_id);
+    struct ws_string* name = ws_value_string_get(&args[1].string);
+    if (unlikely(!name)) {
+        goto out;
+    }
+
+    char* ident = ws_string_raw(name); // copies!
+    ws_object_unref(&name->obj);
+    if (likely(ident)) {
+        res = ws_object_attr_write(obj, ident, &args[2].value);
+    }
+
+    free(ident);
+
+out:
+    ws_object_unref(obj);
+    return res;
+}
+
+int
 ws_builtin_cmd_is_instance_of(
     union ws_value_union* args
 ) {

--- a/src/command/object.commands
+++ b/src/command/object.commands
@@ -2,4 +2,5 @@ hastypename;regular
 call;regular
 has_meth;regular
 has_attr;regular
+get_attr;regular
 is_instance_of;regular

--- a/src/command/object.commands
+++ b/src/command/object.commands
@@ -3,4 +3,5 @@ call;regular
 has_meth;regular
 has_attr;regular
 get_attr;regular
+set_attr;regular
 is_instance_of;regular

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -406,6 +406,11 @@ ws_object_attr_read(
 
     void* member_pos = (void *) (((char *) self) + offset);
     switch (type) {
+    case WS_OBJ_ATTR_TYPE_BOOL:
+        ws_value_bool_set((struct ws_value_bool*) dest,
+                          (bool) *((bool*) member_pos));
+        break;
+
     case WS_OBJ_ATTR_TYPE_CHAR:
         ws_value_int_set((struct ws_value_int*) dest,
                          (char) *((int32_t*) member_pos));

--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -42,6 +42,7 @@
 #include "values/object_id.h"
 #include "values/set.h"
 #include "values/string.h"
+#include "values/value_type.h"
 
 static struct ws_logger_context log_ctx = {
     .prefix = "[Object] ",
@@ -62,11 +63,13 @@ struct ws_object_attribute const WS_OBJECT_ATTRS_OBJECT[] = {
 //        .name = "id",
 //        .offset_in_struct = offsetof(struct ws_object, id),// stddef: offsetof
 //        .type = WS_OBJ_ATTR_NO_TYPE,
+//        .vtype = WS_VALUE_TYPE_NONE,
 //    }
     {
         .name = NULL,
         .offset_in_struct = 0,
-        .type = 0
+        .type = 0,
+        .vtype = WS_VALUE_TYPE_NONE,
     },
 };
 
@@ -585,6 +588,30 @@ ws_object_attr_type(
 err:
     ws_object_unlock(self);
     return WS_OBJ_ATTR_NO_TYPE;
+}
+
+enum ws_value_type
+ws_object_attr_value_type(
+    struct ws_object* self, //!< The object
+    char* ident //!< The identifier for the attribute
+) {
+    ws_object_lock_read(self);
+
+    if (!self->id || !self->id->attribute_table) {
+        goto err;
+    }
+
+    size_t i;
+    for (i = 0; self->id->attribute_table[i].name != NULL; i++) {
+        if (ws_streq(self->id->attribute_table[i].name, ident)) {
+            ws_object_unlock(self);
+            return self->id->attribute_table[i].vtype;
+        }
+    }
+
+err:
+    ws_object_unlock(self);
+    return WS_VALUE_TYPE_NONE;
 }
 
 int

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -469,6 +469,10 @@ ws_object_has_attr(
  *
  * @return zero on success, else negative error code from errno.h
  *      -EINVAL - if the passed `dest` type does not match the attribute type
+ *      -EINVAL - if there is no attribute table
+ *      -ECANCELED - if the requested member is not available
+ *      -EFAULT - If the member has no type (unlikely)
+ *      -ENOMEM - failed to allocate resources
  */
 int
 ws_object_attr_read(

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -49,6 +49,7 @@
 #include "util/attributes.h"
 #include "logger/module.h"
 #include "values/value.h"
+#include "values/value_type.h"
 #include "command/command.h"
 
 /*
@@ -134,7 +135,7 @@ struct ws_object_attribute {
     char const* const   name; //!< Name of the attribute
     size_t              offset_in_struct; //!< Offset in the struct
     enum ws_object_attribute_type type; //!< Attribute type
-
+    enum ws_value_type vtype; //!< Attribute type in ws_value_type shape
 };
 
 /**
@@ -511,6 +512,24 @@ ws_object_attr_type(
 )
 __ws_nonnull__(1, 2)
 ;
+
+
+/**
+ * Get the value-type of an attribute identified by its name
+ *
+ * @memberof ws_object
+ *
+ * @return The value-attribute type of the attribute identified by name or
+ * WS_VALUE_TYPE_NONE
+ */
+enum ws_value_type
+ws_object_attr_value_type(
+    struct ws_object* self, //!< The object
+    char* ident //!< The identifier for the attribute
+)
+__ws_nonnull__(1, 2)
+;
+
 
 /**
  * Compare two ws_object instances

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -113,6 +113,7 @@ typedef uintmax_t (*ws_object_uuid_callback)(struct ws_object*);
 enum ws_object_attribute_type {
     WS_OBJ_ATTR_NO_TYPE = 0,
 
+    WS_OBJ_ATTR_TYPE_BOOL,
     WS_OBJ_ATTR_TYPE_CHAR,
     WS_OBJ_ATTR_TYPE_INT32,
     WS_OBJ_ATTR_TYPE_INT64,


### PR DESCRIPTION
This PR aims for a complete refactoring step in the abstract
shell surface API code, aiming for a big removal of code there
in favour of some abstraction.

PR #625 prepares for the next few steps I want to do here,
to refactor the attribute writing into one API call here.

Blocked by #625.
