### PR TITLE
Fix add_roots_for()

### DIFF
--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -489,8 +489,10 @@ flatten_tab(
         // if we have only one child, we can easily pull out the old root
         size_t pos = (child - tab->nodes.tab) <<
                      (DAG_TAB_CHILD_NUM_EXP * tab->depth);
+
+        void* new_val = *child;
         free(tab->nodes.tab);
-        tab->nodes.tab = child;
+        tab->nodes.tab = new_val;
 
         // we have to adjust depth and start
         --tab->depth;

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -77,16 +77,6 @@ static void**
 create_tab_node(void);
 
 /**
- * Destruct a DAG node
- */
-static void
-destruct_dag_node(
-    struct ws_hotkey_dag_node* node //!< node to destruct (and free)
-)
-__ws_nonnull__(1)
-;
-
-/**
  * Destruct a tab node
  */
 static void
@@ -412,15 +402,6 @@ add_roots_for(
 static void**
 create_tab_node(void) {
     return calloc(DAG_TAB_CHILD_NUM, sizeof(void*));
-}
-
-static void
-destruct_dag_node(
-    struct ws_hotkey_dag_node* node
-) {
-    // deinit and free
-    ws_hotkey_dag_deinit(node);
-    free(node);
 }
 
 static void

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -380,6 +380,9 @@ add_roots_for(
     while ((code < tab->start) || (pos > DAG_TAB_CHILD_NUM)) {
         // we have to create a new node
         void** tab_node = create_tab_node();
+        if (!tab_node) {
+            return -ENOMEM;
+        }
 
         size_t old_root_pos = (tab->start >> step);
 

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -82,7 +82,7 @@ create_tab_node(void);
 static void
 destruct_tab_node(
     void* tab_node, //!< tab node to destruct
-    uint8_t depth //!< depth of the node to destruct
+    int_fast8_t depth //!< depth of the node to destruct
 );
 
 /**
@@ -407,22 +407,20 @@ create_tab_node(void) {
 static void
 destruct_tab_node(
     void* tab_node,
-    uint8_t depth
+    int_fast8_t depth
 ) {
-    if (!tab_node || (depth > DAG_TAB_MAX_DEPTH)) {
+    if (!tab_node) {
         // nothing to do
         return;
     }
-
-    --depth;
 
     void** cur_node = ((void**) tab_node) + DAG_TAB_CHILD_NUM;
     // iterate over all the nodes
     while (cur_node-- > (void**) tab_node) {
         // destruct children
-        if (depth >= 0) {
-            destruct_tab_node(*cur_node, depth);
-        } if (*cur_node) {
+        if (depth > 0) {
+            destruct_tab_node(*cur_node, depth - 1);
+        } else if (*cur_node) {
             ws_hotkey_dag_deinit((struct ws_hotkey_dag_node*) *cur_node);
             free(*cur_node);
         }

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -152,7 +152,7 @@ void
 ws_hotkey_dag_deinit(
     struct ws_hotkey_dag_node* entry_node
 ) {
-    destruct_tab_node(entry_node->table.nodes.tab, entry_node->table.start);
+    destruct_tab_node(entry_node->table.nodes.tab, entry_node->table.depth);
     entry_node->table.nodes.tab = NULL;
     entry_node->table.start = 0;
     entry_node->table.depth = 0;

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -439,10 +439,11 @@ destruct_tab_node(
     // iterate over all the nodes
     while (cur_node-- > (void**) tab_node) {
         // destruct children
-        if (depth) {
+        if (depth >= 0) {
             destruct_tab_node(*cur_node, depth);
-        } else {
-            destruct_dag_node((struct ws_hotkey_dag_node*) cur_node);
+        } if (*cur_node) {
+            ws_hotkey_dag_deinit((struct ws_hotkey_dag_node*) *cur_node);
+            free(*cur_node);
         }
     }
 

--- a/src/input/hotkey_dag.c
+++ b/src/input/hotkey_dag.c
@@ -365,9 +365,9 @@ add_roots_for(
         if (!tab->nodes.tab) {
             return -ENOMEM;
         }
-        if (tab->depth == 0) {
-            tab->start = code & ~(DAG_TAB_CHILD_NUM - 1);
-        }
+        tab->depth = 0;
+        tab->start = code & ~(DAG_TAB_CHILD_NUM - 1);
+        return 0;
     }
 
     // step on which the node is based.

--- a/src/input/hotkey_dag.h
+++ b/src/input/hotkey_dag.h
@@ -57,7 +57,7 @@ struct ws_hotkey_dag_tab {
         void** tab;
     } nodes; //!< @protected nodes in this tab
     uint16_t start; //!< @protected stating point in the code space
-    uint8_t depth; //!< @protected indicator on how far we are from dag nodes
+    int8_t depth; //!< @protected indicator on how far we are from dag nodes
 };
 
 /**


### PR DESCRIPTION
During investigation of issue #601, @matthiasbeyer found that, apparently, the function `add_roots_for()` misbehaves. Thi PR is aimed at fixing that function.

Note that this PR contains a rewrite of that function. It appears that that rewrite either breaks some functionality or uncovers another bug. I'd suggest investigating whether the other two fixes resolve the issue, e.g. whether the rewrite can be omitted. That would be a job for @matthiasbeyer as he found the original bug.
