### PR TITLE
Add warning to wayland buffer

### DIFF
--- a/src/compositor/wayland/buffer.h
+++ b/src/compositor/wayland/buffer.h
@@ -46,6 +46,11 @@
 /**
  * Wayland buffer type
  *
+ * @warning This is __not__ a `ws_buffer`! To get the `ws_buffer` contained in
+ *          this object, use `ws_wayland_buffer_get_buffer()`. If you use an
+ *          object of this type as an argument for a `ws_buffer` method, Julian
+ *          Ganz will probably be mad at you and tell you to RTFM.
+ *
  * @extends ws_wayland_obj
  */
 struct ws_wayland_buffer {

--- a/src/compositor/wayland/surface.c
+++ b/src/compositor/wayland/surface.c
@@ -388,7 +388,8 @@ surface_commit_cb(
         return;
     }
 
-    ws_buffer_transfer2texture((struct ws_buffer*) &s->img_buf, &s->texture);
+    ws_buffer_transfer2texture(ws_wayland_buffer_get_buffer(&s->img_buf),
+                               &s->texture);
 
     //!< @todo remove once the HW accelerated compositing is in place
     ws_set_select(&ws_comp_ctx.monitors, NULL, NULL,


### PR DESCRIPTION
...to prevent devs from using it as a `ws_buffer` and filing bug-reports
because the method segfaults.

Should prevent issues like #633 from popping up.
