### PR TITLE
Add json-serializer error handling

### DIFF
--- a/src/objects/object.c
+++ b/src/objects/object.c
@@ -826,6 +826,13 @@ ws_object_has_cmd(
     return false;
 }
 
+const char*
+ws_object_typename(
+    struct ws_object const* self //!< The object
+) {
+    return (self ? self->id->typestr : NULL);
+}
+
 /*
  *
  * static function implementations

--- a/src/objects/object.h
+++ b/src/objects/object.h
@@ -642,6 +642,18 @@ ws_object_has_cmd(
     char const* ident //!< Name of command to check the object for
 );
 
+/**
+ * Get the typename of the object
+ *
+ * @memberof ws_object
+ *
+ * @return Typename of passed object or NULL on failure
+ */
+const char*
+ws_object_typename(
+    struct ws_object const* self //!< The object
+);
+
 #endif // __WS_OBJECTS_OBJECT_H__
 
 /**

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -194,7 +194,7 @@ serialize(
 
         yajl_gen_status stat = yajl_gen_map_open(ctx->yajlgen);
         if (stat != yajl_gen_status_ok) {
-            //!< @todo error opening map, what to do now?
+            ws_log(&log_ctx, LOG_DEBUG, "Error opening main map");
             return -1;
         }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -336,8 +336,7 @@ serialize_reply_value_reply(
 
     // We haven't serialized anything
     // generate the key for the value reply
-    if (gen_key(ctx, VALUE)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, VALUE))) {
         return -1;
     }
 
@@ -347,8 +346,7 @@ serialize_reply_value_reply(
         return -1;
     }
 
-    if (gen_key(ctx, TRANSACTION_ID)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, TRANSACTION_ID))) {
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -342,7 +342,6 @@ serialize_reply_value_reply(
 
     struct ws_value* v = &((struct ws_value_reply*) self->buffer)->value.value;
     if (serialize_value(ctx, v)) {
-        //!< @todo error?
         return -1;
     }
 
@@ -352,8 +351,8 @@ serialize_reply_value_reply(
 
     size_t id = ws_message_get_id(self->buffer);
     yajl_gen_status stat = yajl_gen_integer(ctx->yajlgen, id);
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error serializing msg id: %i", id);
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -42,6 +42,7 @@
 #include <yajl/yajl_common.h>
 #include <yajl/yajl_gen.h>
 
+#include "logger/module.h"
 #include "objects/message/error_reply.h"
 #include "objects/message/event.h"
 #include "objects/message/message.h"
@@ -54,6 +55,10 @@
 #include "util/arithmetical.h"
 #include "values/object_id.h"
 #include "values/value.h"
+
+static struct ws_logger_context log_ctx = {
+    .prefix = "[Serializer/JSON] ",
+};
 
 /*
  *

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -367,8 +367,7 @@ serialize_event(
 
     // We haven't serialized anything
     // generate the key for the event message
-    if (gen_key(ctx, EVENT)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, EVENT))) {
         return -1;
     }
     // We also know already what we have to serialize, so... let's try it

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -381,8 +381,7 @@ serialize_event(
     }
 
     // We have a '{ "event" : {' in the buffer by now
-    if (gen_key(ctx, EVENT_CTX)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, EVENT_CTX))) {
         return -1;
     }
 
@@ -395,8 +394,7 @@ serialize_event(
     }
 
     // We have a '{ "event" : { <context:map> ' in the buffer by now
-    if (gen_key(ctx, EVENT_NAME)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, EVENT_NAME))) {
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -252,8 +252,8 @@ serialize(
 
     { // lets close the main map now.
         yajl_gen_status stat = yajl_gen_map_close(ctx->yajlgen);
-        if (stat != yajl_gen_status_ok) {
-            //!< @todo error?
+        if (unlikely(stat != yajl_gen_status_ok)) {
+            ws_log(&log_ctx, LOG_DEBUG, "Error closing main map");
             return -1;
         }
     }

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -551,8 +551,8 @@ serialize_object_to_id_string(
     yajl_gen_status stat = yajl_gen_string(ctx->yajlgen,
                                            (unsigned char*) buff,
                                            bufflen - 1);
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error serializing id string");
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -470,12 +470,12 @@ serialize_value(
         {
             stat = yajl_gen_map_open(ctx->yajlgen);
             if (stat != yajl_gen_status_ok) {
-                //!< @todo error?
+                ws_log(&log_ctx, LOG_DEBUG, "Error opening map");
                 return -1;
             }
 
-            if (gen_key(ctx, ws_value_type_get_name(val))) {
-                //!< @todo error?
+            if (unlikely(gen_key(ctx, ws_value_type_get_name(val)))) {
+                ws_log(&log_ctx, LOG_DEBUG, "Error generating map key");
                 return -1;
             }
 
@@ -495,7 +495,7 @@ serialize_value(
             case WS_VALUE_TYPE_SET:
                 stat = yajl_gen_array_open(ctx->yajlgen);
                 if (stat != yajl_gen_status_ok) {
-                    //!< @todo error?
+                    ws_log(&log_ctx, LOG_DEBUG, "Error opening array");
                     return -1;
                 }
 
@@ -509,12 +509,18 @@ serialize_value(
                 break;
 
             default:
-                //!< @todo error?
+                {
+                    const char* ty = ws_value_type_get_name(val);
+                    ws_log(&log_ctx, LOG_DEBUG,
+                           "Unable to serialize '%s' type", ty);
+                }
                 return -1;
             }
 
-            if (stat != yajl_gen_status_ok) {
-                //!< @todo error?
+            if (unlikely(stat != yajl_gen_status_ok)) {
+                const char* ty = ws_value_type_get_name(val);
+                ws_log(&log_ctx, LOG_DEBUG,
+                       "Unable to serialize '%s' type", ty);
                 return -1;
             }
 
@@ -523,7 +529,8 @@ serialize_value(
     }
 
     if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+        const char* vname = ws_value_type_get_name(val);
+        ws_log(&log_ctx, LOG_DEBUG, "Error serializing value: '%s'", vname);
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -376,7 +376,7 @@ serialize_event(
     // We have a JSON Object "event"
     yajl_gen_status stat = yajl_gen_map_open(ctx->yajlgen);
     if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+        ws_log(&log_ctx, LOG_DEBUG, "Error opening map for event");
         return -1;
     }
 
@@ -389,7 +389,7 @@ serialize_event(
 
     // We have a '{ "event" : { "context" : ' in the buffer by now
     if (serialize_value(ctx, &ev->context.value) != 0) {
-        //!< @todo error?
+        ws_log(&log_ctx, LOG_DEBUG, "Error serializing value for event");
         return -1;
     }
 
@@ -407,7 +407,7 @@ serialize_event(
 
         stat = yajl_gen_string(ctx->yajlgen, (unsigned char*) plain, len);
         if (stat != yajl_gen_status_ok) {
-            //!< @todo error?
+            ws_log(&log_ctx, LOG_DEBUG, "Error serializing event name");
             return -1;
         }
     }
@@ -415,7 +415,7 @@ serialize_event(
     // lets close the event map now.
     stat = yajl_gen_map_close(ctx->yajlgen);
     if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+        ws_log(&log_ctx, LOG_DEBUG, "Error closing map for event");
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -494,11 +494,18 @@ serialize_value(
                     return -1;
                 }
 
-                //!< @todo check return value ... might return before ready
-                ws_value_set_select((struct ws_value_set*) val, NULL, NULL,
-                        (int (*)(void*, void const*))
-                            serialize_object_to_id_string,
-                        ctx);
+                {
+                    int r = ws_value_set_select((struct ws_value_set*) val,
+                                                 NULL, NULL,
+                                                (int (*)(void*, void const*))
+                                                serialize_object_to_id_string,
+                                                ctx);
+
+                    if (unlikely(r < 0)) {
+                        ws_log(&log_ctx, LOG_DEBUG, "Error serializing set");
+                        return -1;
+                    }
+                }
 
                 stat = yajl_gen_array_close(ctx->yajlgen);
                 break;

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -272,8 +272,7 @@ write_buffer:
     if (ctx->yajl_buffer_size <= nbuf) {
         // We are ready now, as the yajl buffer is smaller or of equal size
         // as the buffer we just wrote to
-
-        //!< @todo do I need to free the self->buffer object here?
+        ws_object_unref(&self->buffer->obj);
         self->buffer = NULL; // "I am ready here!"
     } else {
         // We must wait until we get a buffer where we can write the rest

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -53,6 +53,7 @@
 #include "serialize/json/serializer_state.h"
 #include "serialize/serializer.h"
 #include "util/arithmetical.h"
+#include "util/condition.h"
 #include "values/object_id.h"
 #include "values/value.h"
 
@@ -234,8 +235,10 @@ serialize(
             }
 
             int retval = FUNC_TAB[i].serf(self);
-            if (retval < 0) {
-                //!< @todo something went wrong serializing the event. Error?
+            if (unlikely(retval < 0)) {
+                char const* name = ws_object_typename(&self->buffer->obj);
+                ws_log(&log_ctx, LOG_DEBUG,
+                       "Serializing error when serializing '%s'", name);
                 return retval;
             }
             serialized = true;

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -566,8 +566,8 @@ gen_key(
                                            (const unsigned char*) str,
                                            strlen(str));
 
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error generating key: '%s'", str);
         return -EAGAIN;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -483,7 +483,6 @@ serialize_value(
                     obj_id = (struct ws_value_object_id*) val;
                     struct ws_object* object = ws_value_object_id_get(obj_id);
                     if (serialize_object_to_id_string(ctx, object)) {
-                        //!< @todo error?
                         return -1;
                     }
                 }

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -292,8 +292,7 @@ serialize_reply_error_reply(
     struct ws_error_reply* r = (struct ws_error_reply*) self->buffer;
     struct serializer_context* ctx = (struct serializer_context*) self->state;
 
-    if (gen_key(ctx, ERROR_CODE)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, ERROR_CODE))) {
         return -1;
     }
 
@@ -304,8 +303,7 @@ serialize_reply_error_reply(
         return -1;
     }
 
-    if (gen_key(ctx, ERROR_DESC)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, ERROR_DESC))) {
         return -1;
     }
 
@@ -316,8 +314,7 @@ serialize_reply_error_reply(
         return -1;
     }
 
-    if (gen_key(ctx, ERROR_CAUSE)) {
-        //!< @todo error?
+    if (unlikely(gen_key(ctx, ERROR_CAUSE))) {
         return -1;
     }
 

--- a/src/serialize/json/serializer.c
+++ b/src/serialize/json/serializer.c
@@ -298,8 +298,8 @@ serialize_reply_error_reply(
 
     yajl_gen_status stat = yajl_gen_integer(ctx->yajlgen,
                                             ws_error_reply_get_code(r));
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error generating int for error reply");
         return -1;
     }
 
@@ -309,8 +309,8 @@ serialize_reply_error_reply(
 
     char const* tmp = ws_error_reply_get_description(r);
     stat = yajl_gen_string(ctx->yajlgen, (unsigned char*) tmp, strlen(tmp));
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error generating desc: '%s'", tmp);
         return -1;
     }
 
@@ -320,8 +320,8 @@ serialize_reply_error_reply(
 
     tmp = ws_error_reply_get_cause(r);
     stat = yajl_gen_string(ctx->yajlgen, (unsigned char*) tmp, strlen(tmp));
-    if (stat != yajl_gen_status_ok) {
-        //!< @todo error?
+    if (unlikely(stat != yajl_gen_status_ok)) {
+        ws_log(&log_ctx, LOG_DEBUG, "Error generating cause: '%s'", tmp);
         return -1;
     }
 


### PR DESCRIPTION
This PR targets #635.

It only contains logging calls by now, as I'm not sure what to do when
the serialization fails. It should not fail, of course. But if that happens
we could almost do an shutdown, as the serialization should only fail if
no memory is left, and ... yeah... you get it, I guess.

What to do in case of error? Clean up, of course, but what else? Is
logging enough?
